### PR TITLE
fix: bootloader fails to build

### DIFF
--- a/bootloader/usb_config.h
+++ b/bootloader/usb_config.h
@@ -7,7 +7,7 @@
 #define USB_DM 3
 #define USB_DP 4
 #define USB_DPU 5
-#define USB_PORT GPIOD
+#define USB_PORT D
 
 #define RV003USB_OPTIMIZE_FLASH 1
 


### PR DESCRIPTION
~/rv003usb$ cd bootloader/
~/rv003usb/bootloader$ make clean build
rm -rf bootloader.elf bootloader.bin bootloader.hex bootloader.lst bootloader.map bootloader.hex || true
riscv64-unknown-elf-gcc -o bootloader.elf bootloader.c ../rv003usb/rv003usb.S -g -Os -flto -ffunction-sections -static-libgcc -march=rv32ec -mabi=ilp32e -I/usr/include/newlib -I../ch32v003fun/ch32v003fun/../extralibs -I../ch32v003fun/ch32v003fun -nostdlib -I. -Wall -I. -I../lib -DUSE_TINY_BOOT -I../rv003usb -T ch32v003fun-usb-bootloader.ld -Wl,--gc-sections -L../ch32v003fun/ch32v003fun/../misc -lgcc
../rv003usb/rv003usb.S: Assembler messages:
../rv003usb/rv003usb.S:54: Error: illegal operands `la a5,GPIO((GPIO_TypeDef*)(((0x40000000)+0x10000)+0x1400))_BASE'
../rv003usb/rv003usb.S:567: Error: illegal operands `la a5,GPIO((GPIO_TypeDef*)(((0x40000000)+0x10000)+0x1400))_BASE'
make: *** [../ch32v003fun/ch32v003fun/ch32v003fun.mk:27: bootloader.elf] Error 1


Fixed by updating usb_config.h: "USB_PORT GPIOD" -> "USB_PORT D"