### PR TITLE
Change "go nowhere" location for debug timer when disabled

### DIFF
--- a/rv003usb/rv003usb.S
+++ b/rv003usb/rv003usb.S
@@ -23,7 +23,7 @@
 #define	RESTORE_DEBUG_MARKER(x) lw	x4, x(sp)
 #define SAVE_DEBUG_MARKER(x)	sw	x4, x(sp)
 #else
-#define DEBUG_TICK_SETUP la x4, (TIM1_BASE + 0x44) 	// for debug (Go nowhere)
+#define DEBUG_TICK_SETUP la x4, (TIM1_BASE + 0x58) 	// for debug (Go nowhere)
 #define DEBUG_TICK_MARK .balign 4; sw x0, 0(x4)
 #define	RESTORE_DEBUG_MARKER(x) lw	x4, x(sp)
 #define SAVE_DEBUG_MARKER(x)	sw	x4, x(sp)


### PR DESCRIPTION
0x44 is the BDTR register, which incidentally contains the output enable bit (and breaks PWM output). 0x58 at least doesn't contain anything according to the data sheet and doesn't break anything for me