### PR TITLE
Windows support for bootloader

### DIFF
--- a/bootloader/Makefile
+++ b/bootloader/Makefile
@@ -12,7 +12,7 @@ EXTRA_CFLAGS:=-I. -I../lib -DUSE_TINY_BOOT -I../rv003usb
 # Otherwise just a test.
 LINKER_SCRIPT:=ch32v003fun-usb-bootloader.ld
 WRITE_SECTION:=bootloader
-FLASH_COMMAND:=$(CH32V003FUN)/../minichlink/minichlink -a -U -w $(TARGET).bin $(WRITE_SECTION) -B
+FLASH_COMMAND:=$(CH32V003FUN)/../minichlink/minichlink -a -w $(TARGET).bin $(WRITE_SECTION) -B
 
 include ../ch32v003fun/ch32v003fun/ch32v003fun.mk
 

--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -261,7 +261,7 @@ void usb_pid_handle_data( uint32_t this_token, uint8_t * data, uint32_t which_da
 				start[i] = data[i];//((intptr_t)data)>>(i*8);
 			e->count ++;
 
-			if( start + length >= scratchpad + SCRATCHPAD_SIZE )
+			if( start + length - 3 >= scratchpad + SCRATCHPAD_SIZE )
 			{
 				// If the last 4 bytes are 0x1234abcd, then we can go!
 				uint32_t * last4 = (uint32_t*)(start + 4);					

--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -261,7 +261,7 @@ void usb_pid_handle_data( uint32_t this_token, uint8_t * data, uint32_t which_da
 				start[i] = data[i];//((intptr_t)data)>>(i*8);
 			e->count ++;
 
-			if( e->count >= SCRATCHPAD_SIZE )
+			if( start + length >= scratchpad + SCRATCHPAD_SIZE )
 			{
 				// If the last 4 bytes are 0x1234abcd, then we can go!
 				uint32_t * last4 = (uint32_t*)(start + 4);					

--- a/bootloader/make_win.bat
+++ b/bootloader/make_win.bat
@@ -1,0 +1,8 @@
+REM Bad USB Operation on pgm-wch-linke.c ? Zadig!
+del bootloader.bin
+del bootloader.elf
+del bootloader.hex
+del bootloader.lst
+del bootloader.map
+make build
+..\ch32v003fun\minichlink\minichlink.exe -a -w bootloader.bin bootloader -B

--- a/bootloader/usb_config.h
+++ b/bootloader/usb_config.h
@@ -39,7 +39,7 @@ static const uint8_t special_hid_desc[] = {
   HID_USAGE_PAGE ( HID_USAGE_PAGE_DESKTOP      )                 ,
   HID_USAGE      ( 0xff  )                 , // Needed?
   HID_COLLECTION ( HID_COLLECTION_APPLICATION )                 ,
-	HID_REPORT_SIZE ( 8 ),
+    HID_REPORT_SIZE ( 8 ),
     HID_REPORT_COUNT ( 127 ) ,
     HID_REPORT_ID    ( 0xaa                                   )
     HID_USAGE        ( 0xff              ) ,

--- a/bootloader/usb_config.h
+++ b/bootloader/usb_config.h
@@ -39,10 +39,11 @@ static const uint8_t special_hid_desc[] = {
   HID_USAGE_PAGE ( HID_USAGE_PAGE_DESKTOP      )                 ,
   HID_USAGE      ( 0xff  )                 , // Needed?
   HID_COLLECTION ( HID_COLLECTION_APPLICATION )                 ,
+	HID_REPORT_SIZE ( 8 ),
+    HID_REPORT_COUNT ( 127 ) ,
     HID_REPORT_ID    ( 0xaa                                   )
     HID_USAGE        ( 0xff              ) ,
     HID_FEATURE      ( HID_DATA | HID_ARRAY | HID_ABSOLUTE    ) ,
-    HID_REPORT_COUNT ( 128 ) ,
   HID_COLLECTION_END
 };
 
@@ -85,7 +86,7 @@ static const uint8_t config_descriptor[] = {  //Mostly stolen from a USB mouse I
 	0x05, //Endpoint Descriptor (Must be 5)
 	0x81, //Endpoint Address
 	0x03, //Attributes
-	0x40,	0x00, //Size
+	0x08,	0x00, //Size
 	0xff, //Interval
 };
 


### PR DESCRIPTION
Adds windows support for the bootloader by fixing the USB and HID descriptors to proper values and adjusting end of scratchpad transfer detection.

Other than Linux, Windows will not allow any communication with a USB device that does not exactly follow the specs and matches USB descriptors.
The original USB descriptor advertises a `wMaxPacketSize` of 64 which is invalid for low speed USB devices, causing enumeration to fail on many host controllers. The maximum allowed for low speed devices is 8 Bytes.
The HID descriptor had a wrong Report Count and was missing a Report Size, resulting in an undefined or zero length of data it would accept.

Also added `make_win.bat` to build and flash the bootloader, as the make-file did not work properly for me on windows.

Fixes issues #21 and #24.