### PR TITLE
make bootloader PORT configurable

### DIFF
--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -79,8 +79,10 @@ int main()
 	}
 #endif
 
+	// GPIO reset.
+	LOCAL_EXP(GPIO,USB_PORT)->CFGLR &= ~( 0xF<<(4*USB_DM) | 0xF<<(4*USB_DP) | 0xF<<(4*USB_DPU) );
 	// GPIO setup.
-	LOCAL_EXP(GPIO,USB_PORT)->CFGLR =
+	LOCAL_EXP(GPIO,USB_PORT)->CFGLR |=
 		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DM) | 
 		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DP) | 
 		(GPIO_Speed_50MHz | GPIO_CNF_OUT_PP)<<(4*USB_DPU);

--- a/bootloader/usb_config.h
+++ b/bootloader/usb_config.h
@@ -4,10 +4,22 @@
 //Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.  For one, 2.
 #define ENDPOINTS 2
 
-#define USB_DM 3
-#define USB_DP 4
-#define USB_DPU 5
-#define USB_PORT D
+/*	
+	CH32V003FUN DevBoard:
+	PD3 D+
+	PD4 D-
+	PD5 D-_PU
+
+	CH32V003J4M6:
+	PC1 D+
+	PC2 D-
+	PC4 D-_PU
+*/
+
+#define USB_DM 3 // USB_DM is the physical USB D+ Pin!
+#define USB_DP 4 // USB_DP is the physical USB D- Pin!
+#define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin!
+#define USB_PORT D // Pins on PORT A, C or D
 
 #define RV003USB_OPTIMIZE_FLASH 1
 


### PR DESCRIPTION
While the Pins already were configurable, the bootloader was still hardcoded to `PORTD`. This will fix it.
Also commented the commonly used Pinout.