### PR TITLE
made USB_DPU optional

### DIFF
--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -79,21 +79,27 @@ int main()
 	}
 #endif
 
-	// GPIO reset.
-	LOCAL_EXP(GPIO,USB_PORT)->CFGLR &= ~( 0xF<<(4*USB_DM) | 0xF<<(4*USB_DP) | 0xF<<(4*USB_DPU) );
+	// GPIO reset D+/D-
+	LOCAL_EXP(GPIO,USB_PORT)->CFGLR &= ~( 0xF<<(4*USB_DM) | 0xF<<(4*USB_DP) );
+		
 	// GPIO setup.
 	LOCAL_EXP(GPIO,USB_PORT)->CFGLR |=
 		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DM) | 
-		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DP) | 
-		(GPIO_Speed_50MHz | GPIO_CNF_OUT_PP)<<(4*USB_DPU);
+		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DP);
 
 	// Configure USB_DP (D-) as an interrupt on falling edge.
 	AFIO->EXTICR = LOCAL_EXP(GPIO_PortSourceGPIO,USB_PORT)<<(USB_DP*2); // Configure EXTI interrupt for USB_DP
 	EXTI->INTENR = 1<<USB_DP; // Enable EXTI interrupt
 	EXTI->FTENR = 1<<USB_DP;  // Enable falling edge trigger for USB_DP (D-)
 
+#ifdef USB_DPU
+	// GPIO reset D- Pull-Up
+	LOCAL_EXP(GPIO,USB_PORT)->CFGLR &= ~( 0xF<<(4*USB_DPU) );
+	// GPIO D- Pull-Up setup.
+	LOCAL_EXP(GPIO,USB_PORT)->CFGLR |= (GPIO_Speed_50MHz | GPIO_CNF_OUT_PP)<<(4*USB_DPU);
 	// This drives USB_DPU (D- Pull-Up) high, which will tell the host that we are going on-bus.
 	LOCAL_EXP(GPIO,USB_PORT)->BSHR = 1<<USB_DPU;
+#endif
 
 	// enable interrupt
 	NVIC_EnableIRQ( EXTI7_0_IRQn );

--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -80,10 +80,18 @@ int main()
 #endif
 
 	// GPIO reset D+/D-
-	LOCAL_EXP(GPIO,USB_PORT)->CFGLR &= ~( 0xF<<(4*USB_DM) | 0xF<<(4*USB_DP) );
+	LOCAL_EXP(GPIO,USB_PORT)->CFGLR &= ~( 0xF<<(4*USB_DM) | 0xF<<(4*USB_DP) 
+#ifdef USB_DPU
+		// GPIO reset D- Pull-Up
+		| 0xF<<(4*USB_DPU)
+#endif
+	);
 		
 	// GPIO setup.
 	LOCAL_EXP(GPIO,USB_PORT)->CFGLR |=
+#ifdef USB_DPU
+		(GPIO_Speed_50MHz | GPIO_CNF_OUT_PP)<<(4*USB_DPU) |
+#endif
 		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DM) | 
 		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DP);
 
@@ -93,10 +101,6 @@ int main()
 	EXTI->FTENR = 1<<USB_DP;  // Enable falling edge trigger for USB_DP (D-)
 
 #ifdef USB_DPU
-	// GPIO reset D- Pull-Up
-	LOCAL_EXP(GPIO,USB_PORT)->CFGLR &= ~( 0xF<<(4*USB_DPU) );
-	// GPIO D- Pull-Up setup.
-	LOCAL_EXP(GPIO,USB_PORT)->CFGLR |= (GPIO_Speed_50MHz | GPIO_CNF_OUT_PP)<<(4*USB_DPU);
 	// This drives USB_DPU (D- Pull-Up) high, which will tell the host that we are going on-bus.
 	LOCAL_EXP(GPIO,USB_PORT)->BSHR = 1<<USB_DPU;
 #endif

--- a/bootloader/usb_config.h
+++ b/bootloader/usb_config.h
@@ -18,7 +18,7 @@
 
 #define USB_DM 3 // USB_DM is the physical USB D+ Pin!
 #define USB_DP 4 // USB_DP is the physical USB D- Pin!
-#define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin!
+#define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
 #define USB_PORT D // Pins on PORT A, C or D
 
 #define RV003USB_OPTIMIZE_FLASH 1

--- a/demo_composite_hid/usb_config.h
+++ b/demo_composite_hid/usb_config.h
@@ -4,10 +4,10 @@
 //Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.
 #define ENDPOINTS 3
 
-#define USB_DM 3
-#define USB_DP 4
-#define USB_DPU 5
-#define USB_PORT D
+#define USB_DM 3 // USB_DM is the physical USB D+ Pin!
+#define USB_DP 4 // USB_DP is the physical USB D- Pin!
+#define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
+#define USB_PORT D // Pins on PORT A, C or D
 
 #define RV003USB_OPTIMIZE_FLASH 1
 #define RV003USB_EVENT_DEBUGGING 0

--- a/demo_gamepad/usb_config.h
+++ b/demo_gamepad/usb_config.h
@@ -4,10 +4,10 @@
 //Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.
 #define ENDPOINTS 2
 
-#define USB_DM 3
-#define USB_DP 4
-#define USB_DPU 5
-#define USB_PORT D
+#define USB_DM 3 // USB_DM is the physical USB D+ Pin!
+#define USB_DP 4 // USB_DP is the physical USB D- Pin!
+#define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
+#define USB_PORT D // Pins on PORT A, C or D
 
 #define RV003USB_OPTIMIZE_FLASH 0
 #define RV003USB_HANDLE_IN_REQUEST 1

--- a/demo_hidapi/usb_config.h
+++ b/demo_hidapi/usb_config.h
@@ -4,10 +4,10 @@
 //Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.
 #define ENDPOINTS 2
 
-#define USB_DM 3
-#define USB_DP 4
-#define USB_DPU 5
-#define USB_PORT D
+#define USB_DM 3 // USB_DM is the physical USB D+ Pin!
+#define USB_DP 4 // USB_DP is the physical USB D- Pin!
+#define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
+#define USB_PORT D // Pins on PORT A, C or D
 
 #define RV003USB_DEBUG_TIMING      0
 #define RV003USB_OPTIMIZE_FLASH    1


### PR DESCRIPTION
made USB_DPU optional. Just comment out `USB_DPU` if not needed / tied to 3V3 via 1.5K