### PR TITLE
Bootloader timeout configuration with Host detection

### DIFF
--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -79,21 +79,27 @@ int main()
 	}
 #endif
 
-	// GPIO reset.
-	LOCAL_EXP(GPIO,USB_PORT)->CFGLR &= ~( 0xF<<(4*USB_DM) | 0xF<<(4*USB_DP) | 0xF<<(4*USB_DPU) );
+	// GPIO reset D+/D-
+	LOCAL_EXP(GPIO,USB_PORT)->CFGLR &= ~( 0xF<<(4*USB_DM) | 0xF<<(4*USB_DP) );
+		
 	// GPIO setup.
 	LOCAL_EXP(GPIO,USB_PORT)->CFGLR |=
 		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DM) | 
-		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DP) | 
-		(GPIO_Speed_50MHz | GPIO_CNF_OUT_PP)<<(4*USB_DPU);
+		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DP);
 
 	// Configure USB_DP (D-) as an interrupt on falling edge.
 	AFIO->EXTICR = LOCAL_EXP(GPIO_PortSourceGPIO,USB_PORT)<<(USB_DP*2); // Configure EXTI interrupt for USB_DP
 	EXTI->INTENR = 1<<USB_DP; // Enable EXTI interrupt
 	EXTI->FTENR = 1<<USB_DP;  // Enable falling edge trigger for USB_DP (D-)
 
+#ifdef USB_DPU
+	// GPIO reset D- Pull-Up
+	LOCAL_EXP(GPIO,USB_PORT)->CFGLR &= ~( 0xF<<(4*USB_DPU) );
+	// GPIO D- Pull-Up setup.
+	LOCAL_EXP(GPIO,USB_PORT)->CFGLR |= (GPIO_Speed_50MHz | GPIO_CNF_OUT_PP)<<(4*USB_DPU);
 	// This drives USB_DPU (D- Pull-Up) high, which will tell the host that we are going on-bus.
 	LOCAL_EXP(GPIO,USB_PORT)->BSHR = 1<<USB_DPU;
+#endif
 
 	// enable interrupt
 	NVIC_EnableIRQ( EXTI7_0_IRQn );

--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -99,27 +99,22 @@ int main()
 	}
 #endif
 
-#ifdef BOOTLOADER_KEEP_PORT_CFG
-	// GPIO reset only for D+/D-
-	LOCAL_EXP(GPIO,USB_PORT)->CFGLR &= ~( 0xF<<(4*USB_DM) | 0xF<<(4*USB_DP) 
-	#ifdef USB_DPU
-		// GPIO reset for D- Pull-Up
-		| 0xF<<(4*USB_DPU)
-	#endif
-	);
-#endif
 		
 	// GPIO setup.
+	LOCAL_EXP(GPIO,USB_PORT)->CFGLR = (
 #ifdef BOOTLOADER_KEEP_PORT_CFG
-	LOCAL_EXP(GPIO,USB_PORT)->CFGLR |=
+		LOCAL_EXP(GPIO,USB_PORT)->CFGLR 
 #else
-	LOCAL_EXP(GPIO,USB_PORT)->CFGLR = ( 0x44444444 & ~( 0xF<<(4*USB_DM) | 0xF<<(4*USB_DP) 
-	#ifdef USB_DPU
-		// GPIO reset for D- Pull-Up
-		| 0xF<<(4*USB_DPU)
-	#endif
-	)) |
+		0x44444444 // reset value (all input)
 #endif
+		// Reset the USB Pins
+		& ~( 0xF<<(4*USB_DM) | 0xF<<(4*USB_DP) 
+		#ifdef USB_DPU
+			| 0xF<<(4*USB_DPU)
+		#endif
+		)
+	) |
+	// Configure the USB Pins
 #ifdef USB_DPU
 		(GPIO_Speed_50MHz | GPIO_CNF_OUT_PP)<<(4*USB_DPU) |
 #endif

--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -80,10 +80,18 @@ int main()
 #endif
 
 	// GPIO reset D+/D-
-	LOCAL_EXP(GPIO,USB_PORT)->CFGLR &= ~( 0xF<<(4*USB_DM) | 0xF<<(4*USB_DP) );
+	LOCAL_EXP(GPIO,USB_PORT)->CFGLR &= ~( 0xF<<(4*USB_DM) | 0xF<<(4*USB_DP) 
+#ifdef USB_DPU
+		// GPIO reset D- Pull-Up
+		| 0xF<<(4*USB_DPU)
+#endif
+	);
 		
 	// GPIO setup.
 	LOCAL_EXP(GPIO,USB_PORT)->CFGLR |=
+#ifdef USB_DPU
+		(GPIO_Speed_50MHz | GPIO_CNF_OUT_PP)<<(4*USB_DPU) |
+#endif
 		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DM) | 
 		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DP);
 
@@ -93,10 +101,6 @@ int main()
 	EXTI->FTENR = 1<<USB_DP;  // Enable falling edge trigger for USB_DP (D-)
 
 #ifdef USB_DPU
-	// GPIO reset D- Pull-Up
-	LOCAL_EXP(GPIO,USB_PORT)->CFGLR &= ~( 0xF<<(4*USB_DPU) );
-	// GPIO D- Pull-Up setup.
-	LOCAL_EXP(GPIO,USB_PORT)->CFGLR |= (GPIO_Speed_50MHz | GPIO_CNF_OUT_PP)<<(4*USB_DPU);
 	// This drives USB_DPU (D- Pull-Up) high, which will tell the host that we are going on-bus.
 	LOCAL_EXP(GPIO,USB_PORT)->BSHR = 1<<USB_DPU;
 #endif

--- a/bootloader/usb_config.h
+++ b/bootloader/usb_config.h
@@ -18,7 +18,7 @@
 
 #define USB_DM 3 // USB_DM is the physical USB D+ Pin!
 #define USB_DP 4 // USB_DP is the physical USB D- Pin!
-#define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin!
+#define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
 #define USB_PORT D // Pins on PORT A, C or D
 
 #define RV003USB_OPTIMIZE_FLASH 1


### PR DESCRIPTION
Adds two new #defines to configure the bootloader timeout
```c
// Timeout for bootloader after power-up, set to 0 to stay in bootloader forever
// 75ms per unit; 67 ~= 5s
#define BOOTLOADER_TIMEOUT_PWR 67

// Timeout (reset) for bootloader once USB Host is detected, set to 0 to stay in bootloader forever
// 75ms per unit; 0 costs 28 Bytes, >0 costs 48 Bytes; Comment out if not used
#define BOOTLOADER_TIMEOUT_USB 0
```
If set to e.g. 4 and 0 this will cause the bootloader to boot usercode after only 300ms if no USB Host is present. If an USB Host is present on power up, it will stay in bootloader forever. Perfectly for devices that only need USB for firmware updates but are otherwise just powered by battery / USB wallplug.

Also added a flag to configure if the Port used for USB is reset to all Inputs at the start, or kept as is (besides the USB pins). This can save few Bytes if not required, so it's off now by default.

```c
// Set this if you want the bootloader to keep the Port configuration untouched
// Otherwise it will reset all Pins on the Port used to input; costs 8-16 Bytes
#define BOOTLOADER_KEEP_PORT_CFG
```

With all features enabled at max and PORTD used, the bootloader will exceed it's maximum size, so you may have to take some trade-offs.

This includes https://github.com/cnlohr/rv003usb/pull/38