### PR TITLE
WIP: Add configurable Boot-Button

### DIFF
--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -79,21 +79,27 @@ int main()
 	}
 #endif
 
-	// GPIO reset.
-	LOCAL_EXP(GPIO,USB_PORT)->CFGLR &= ~( 0xF<<(4*USB_DM) | 0xF<<(4*USB_DP) | 0xF<<(4*USB_DPU) );
+	// GPIO reset D+/D-
+	LOCAL_EXP(GPIO,USB_PORT)->CFGLR &= ~( 0xF<<(4*USB_DM) | 0xF<<(4*USB_DP) );
+		
 	// GPIO setup.
 	LOCAL_EXP(GPIO,USB_PORT)->CFGLR |=
 		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DM) | 
-		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DP) | 
-		(GPIO_Speed_50MHz | GPIO_CNF_OUT_PP)<<(4*USB_DPU);
+		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DP);
 
 	// Configure USB_DP (D-) as an interrupt on falling edge.
 	AFIO->EXTICR = LOCAL_EXP(GPIO_PortSourceGPIO,USB_PORT)<<(USB_DP*2); // Configure EXTI interrupt for USB_DP
 	EXTI->INTENR = 1<<USB_DP; // Enable EXTI interrupt
 	EXTI->FTENR = 1<<USB_DP;  // Enable falling edge trigger for USB_DP (D-)
 
+#ifdef USB_DPU
+	// GPIO reset D- Pull-Up
+	LOCAL_EXP(GPIO,USB_PORT)->CFGLR &= ~( 0xF<<(4*USB_DPU) );
+	// GPIO D- Pull-Up setup.
+	LOCAL_EXP(GPIO,USB_PORT)->CFGLR |= (GPIO_Speed_50MHz | GPIO_CNF_OUT_PP)<<(4*USB_DPU);
 	// This drives USB_DPU (D- Pull-Up) high, which will tell the host that we are going on-bus.
 	LOCAL_EXP(GPIO,USB_PORT)->BSHR = 1<<USB_DPU;
+#endif
 
 	// enable interrupt
 	NVIC_EnableIRQ( EXTI7_0_IRQn );

--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -99,27 +99,22 @@ int main()
 	}
 #endif
 
-#ifdef BOOTLOADER_KEEP_PORT_CFG
-	// GPIO reset only for D+/D-
-	LOCAL_EXP(GPIO,USB_PORT)->CFGLR &= ~( 0xF<<(4*USB_DM) | 0xF<<(4*USB_DP) 
-	#ifdef USB_DPU
-		// GPIO reset for D- Pull-Up
-		| 0xF<<(4*USB_DPU)
-	#endif
-	);
-#endif
 		
 	// GPIO setup.
+	LOCAL_EXP(GPIO,USB_PORT)->CFGLR = (
 #ifdef BOOTLOADER_KEEP_PORT_CFG
-	LOCAL_EXP(GPIO,USB_PORT)->CFGLR |=
+		LOCAL_EXP(GPIO,USB_PORT)->CFGLR 
 #else
-	LOCAL_EXP(GPIO,USB_PORT)->CFGLR = ( 0x44444444 & ~( 0xF<<(4*USB_DM) | 0xF<<(4*USB_DP) 
-	#ifdef USB_DPU
-		// GPIO reset for D- Pull-Up
-		| 0xF<<(4*USB_DPU)
-	#endif
-	)) |
+		0x44444444 // reset value (all input)
 #endif
+		// Reset the USB Pins
+		& ~( 0xF<<(4*USB_DM) | 0xF<<(4*USB_DP) 
+		#ifdef USB_DPU
+			| 0xF<<(4*USB_DPU)
+		#endif
+		)
+	) |
+	// Configure the USB Pins
 #ifdef USB_DPU
 		(GPIO_Speed_50MHz | GPIO_CNF_OUT_PP)<<(4*USB_DPU) |
 #endif

--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -80,10 +80,18 @@ int main()
 #endif
 
 	// GPIO reset D+/D-
-	LOCAL_EXP(GPIO,USB_PORT)->CFGLR &= ~( 0xF<<(4*USB_DM) | 0xF<<(4*USB_DP) );
+	LOCAL_EXP(GPIO,USB_PORT)->CFGLR &= ~( 0xF<<(4*USB_DM) | 0xF<<(4*USB_DP) 
+#ifdef USB_DPU
+		// GPIO reset D- Pull-Up
+		| 0xF<<(4*USB_DPU)
+#endif
+	);
 		
 	// GPIO setup.
 	LOCAL_EXP(GPIO,USB_PORT)->CFGLR |=
+#ifdef USB_DPU
+		(GPIO_Speed_50MHz | GPIO_CNF_OUT_PP)<<(4*USB_DPU) |
+#endif
 		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DM) | 
 		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DP);
 
@@ -93,10 +101,6 @@ int main()
 	EXTI->FTENR = 1<<USB_DP;  // Enable falling edge trigger for USB_DP (D-)
 
 #ifdef USB_DPU
-	// GPIO reset D- Pull-Up
-	LOCAL_EXP(GPIO,USB_PORT)->CFGLR &= ~( 0xF<<(4*USB_DPU) );
-	// GPIO D- Pull-Up setup.
-	LOCAL_EXP(GPIO,USB_PORT)->CFGLR |= (GPIO_Speed_50MHz | GPIO_CNF_OUT_PP)<<(4*USB_DPU);
 	// This drives USB_DPU (D- Pull-Up) high, which will tell the host that we are going on-bus.
 	LOCAL_EXP(GPIO,USB_PORT)->BSHR = 1<<USB_DPU;
 #endif

--- a/bootloader/usb_config.h
+++ b/bootloader/usb_config.h
@@ -18,7 +18,7 @@
 
 #define USB_DM 3 // USB_DM is the physical USB D+ Pin!
 #define USB_DP 4 // USB_DP is the physical USB D- Pin!
-#define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin!
+#define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
 #define USB_PORT D // Pins on PORT A, C or D
 
 #define RV003USB_OPTIMIZE_FLASH 1


### PR DESCRIPTION
This adds the option to configure a Button you have to press during boot to enter the Bootloader instead of (or in addition to) using Timeouts.
The Pin can be configured freely and even be on a different Port than the USB. It can be set to be a floating input, or pulled up or down. The level that triggers the bootloader can also be configured.

~~~c
// Bootloader Button Config
// If you want to use a Button during boot to enter bootloader, use these defines 
// to setup the Button. If you do, it makes sense to also set DISABLE_BOOTLOAD above, 
// set BOOTLOADER_TIMEOUT_PWR to 0 and disable BOOTLOADER_TIMEOUT_USB
#define BOOTLOADER_BTN_PORT D
#define BOOTLOADER_BTN_PIN 2
#define BOOTLOADER_BTN_TRIG_LEVEL 0 // 1 = HIGH; 0 = LOW
#define BOOTLOADER_BTN_PULL 1 // 1 = Pull-Up; 0 = Pull-Down; Optional, comment out for floating input
~~~

While you can still use the Timeouts and USB Host detection feature from https://github.com/cnlohr/rv003usb/pull/39 together with the button, it makes sense to disable them. All features together won't fit the 1920 Bytes anymore.

~~~c
#define DISABLE_BOOTLOAD
#define BOOTLOADER_TIMEOUT_PWR 0
//#define BOOTLOADER_TIMEOUT_USB 0
~~~

This includes https://github.com/cnlohr/rv003usb/pull/39 and https://github.com/cnlohr/rv003usb/pull/38