### PR TITLE
fix composite_hid descriptor and add re-enumeration delay

### DIFF
--- a/demo_composite_hid/demo_composite_hid.c
+++ b/demo_composite_hid/demo_composite_hid.c
@@ -6,6 +6,7 @@
 int main()
 {
 	SystemInit();
+	Delay_Ms(200); // Ensures USB re-enumeration after bootloader or reset
 	usb_setup();
 	while(1)
 	{
@@ -48,10 +49,10 @@ void usb_handle_user_in_request( struct usb_endpoint * e, uint8_t * scratchpad, 
 
 		i++;
 
-		// Press the 'b' button every second or so.
+		// Press a Key every second or so.
 		if( (i & 0x7f) == 0 )
 		{
-			tsajoystick[4] = 5;
+			tsajoystick[4] = 0x05; // 0x05 = "b"; 0x53 = NUMLOCK; 0x39 = CAPSLOCK;
 		}
 		else
 		{

--- a/demo_composite_hid/demo_composite_hid.c
+++ b/demo_composite_hid/demo_composite_hid.c
@@ -6,7 +6,7 @@
 int main()
 {
 	SystemInit();
-	Delay_Ms(200); // Ensures USB re-enumeration after bootloader or reset
+	Delay_Ms(1); // Ensures USB re-enumeration after bootloader or reset; Spec demand >2.5µs ( TDDIS )
 	usb_setup();
 	while(1)
 	{

--- a/demo_composite_hid/usb_config.h
+++ b/demo_composite_hid/usb_config.h
@@ -41,7 +41,7 @@ static const uint8_t device_descriptor[] = {
 
 static const uint8_t mouse_hid_desc[] = {  //From http://eleccelerator.com/tutorial-about-usb-hid-report-descriptors/
 	HID_USAGE_PAGE( HID_USAGE_PAGE_DESKTOP ),         // USAGE_PAGE (Generic Desktop)
-	HID_USAGE( HID_USAGE_DESKTOP_TABLET_PC_SYSTEM ),  // USAGE (Mouse), Ok actually a tablet but we apply relative motion!
+	HID_USAGE( HID_USAGE_DESKTOP_MOUSE ),  // USAGE (Mouse)
 	HID_COLLECTION ( HID_COLLECTION_APPLICATION ),    // COLLECTION (Application)
 		HID_USAGE( HID_USAGE_DESKTOP_POINTER ),       //   USAGE (Pointer)
 		HID_COLLECTION ( HID_COLLECTION_PHYSICAL ),   //   COLLECTION (Physical)
@@ -69,12 +69,14 @@ static const uint8_t mouse_hid_desc[] = {  //From http://eleccelerator.com/tutor
 	HID_COLLECTION_END,                               // END_COLLECTIONs
 
 	// Tack this on to do custom HID commands.
+	/*
 	HID_COLLECTION ( HID_COLLECTION_APPLICATION )                 ,
 		HID_REPORT_ID    ( 0xaa                                   )
 		HID_USAGE        ( 0xff              ) ,
 		HID_FEATURE      ( HID_DATA | HID_ARRAY | HID_ABSOLUTE    ) ,
 		HID_REPORT_COUNT ( 8 ) ,
 	HID_COLLECTION_END,
+	*/
 };
 
 //From http://codeandlife.com/2012/06/18/usb-hid-keyboard-with-v-usb/

--- a/demo_gamepad/demo_gamepad.c
+++ b/demo_gamepad/demo_gamepad.c
@@ -6,7 +6,7 @@
 int main()
 {
 	SystemInit();
-	Delay_Ms(200); // Ensures USB re-enumeration after bootloader or reset
+	Delay_Ms(1); // Ensures USB re-enumeration after bootloader or reset; Spec demand >2.5µs ( TDDIS )
 	usb_setup();
 	while(1);
 }

--- a/demo_gamepad/demo_gamepad.c
+++ b/demo_gamepad/demo_gamepad.c
@@ -6,6 +6,7 @@
 int main()
 {
 	SystemInit();
+	Delay_Ms(200); // Ensures USB re-enumeration after bootloader or reset
 	usb_setup();
 	while(1);
 }

--- a/demo_hidapi/demo_hidapi.c
+++ b/demo_hidapi/demo_hidapi.c
@@ -25,6 +25,7 @@ uint32_t WS2812BLEDCallback( int wordno )
 int main()
 {
 	SystemInit();
+	Delay_Ms(200); // Ensures USB re-enumeration after bootloader or reset
 	usb_setup();
 
 	GPIOD->CFGLR = ( ( GPIOD->CFGLR ) & (~( 0xf << (4*2) )) ) | 

--- a/demo_hidapi/demo_hidapi.c
+++ b/demo_hidapi/demo_hidapi.c
@@ -25,7 +25,7 @@ uint32_t WS2812BLEDCallback( int wordno )
 int main()
 {
 	SystemInit();
-	Delay_Ms(200); // Ensures USB re-enumeration after bootloader or reset
+	Delay_Ms(1); // Ensures USB re-enumeration after bootloader or reset; Spec demand >2.5µs ( TDDIS )
 	usb_setup();
 
 	GPIOD->CFGLR = ( ( GPIOD->CFGLR ) & (~( 0xf << (4*2) )) ) | 


### PR DESCRIPTION
The composite_hid descriptor didn't work properly on Windows (Keyboard worked, but Mouse didn't). With this change it works on Windows, Linux and MacOS.  
Also added a delay between `SystemInit()` and `usb_setup()` to ensure re-enumeration after bootloader or reset. This works because the `D-` Pull-Up is disabled in that period. With a hardwired pullup one would need `D-` to be pulled low actively to achieve the same.