### PR TITLE
Correct usage of USB_DM/USB_DP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Using USB on the CH32V003
 
-Ever wanted a 10 cent USB-capable processor? Well, look no further. RV003USB allows you to, in firmware connect a 10 cent RISC-V to a computer with USB. It is fundamentally just a pin-change interrupt routine that runs in assembly, and some C code to handle higher level functionality.
+Ever wanted a 10 cent USB low-speed capable processor? Well, look no further. RV003USB allows you to, in firmware, connect a 10 cent RISC-V to a computer with USB. It is fundamentally just a pin-change interrupt routine that runs in assembly, and some C code to handle higher level functionality.
 
 ### It's small!
 
-The bootloader version of the tool can create a HID device, enumerate and allow execution of code on-device in 1,920 bytes of code.  Basic HID setups are approximately 2kB, like the Joystick demo.
+The bootloader version of the tool can create a HID device, enumerate and allow execution of code on-device in 1,920 bytes of code. Basic HID setups are approximately 2kB, like the Joystick demo.
 
 ### It's simple!
 
-The core assembly code is very basic, having both an [interrupt](https://github.com/cnlohr/rv003usb/blob/master/rv003usb/rv003usb.S#L43) and [code to send](https://github.com/cnlohr/rv003usb/blob/master/rv003usb/rv003usb.S#L547).   And only around [250 lines of C](https://github.com/cnlohr/rv003usb/blob/master/rv003usb/rv003usb.c) code to facilitate the rest of the USB protocol.    
+The core assembly code is very basic, having both an [interrupt](https://github.com/cnlohr/rv003usb/blob/master/rv003usb/rv003usb.S#L43) and [code to send](https://github.com/cnlohr/rv003usb/blob/master/rv003usb/rv003usb.S#L547). Additionally only around [250 lines of C](https://github.com/cnlohr/rv003usb/blob/master/rv003usb/rv003usb.c) code to facilitate the rest of the USB protocol.
 
 ### It's adaptable!
 
@@ -20,21 +20,46 @@ It shows both how to be a normal USB device, as well as how to write programs to
 
 ![Example Schematic](https://raw.githubusercontent.com/cnlohr/rv003usb/master/doc/schematic.png)
 
-The reason why D+/D- is "flipped" from what is listed in `usb_config.h` is because for USB low-speed, the D+/D- lines are swapped. It is frustratingly unintuitive. Also note that if you change the pin assignments for your custom hardware, you will need to run `make clean` after any hardware changes (and then run `make`).
-
-As-written you **cannot** use PD6,7 or PC6,7 in any combination with the USB stack.  You must use other pins.  Sorry, let me know if you find a way.
-
  * `U1` is a CH32V003
  * `J1` is a USB type C connector.
- * `R1` 1.5k 5% is required under all configurations, though it may connect† D- to DPU or VCC if the intent is for the part to always be on-bus.
+ * `R1` 1.5k 5% is required under all configurations, though it may connect D- to DPU or VCC if the intent is for the part to always be on-bus.
  * `U2`, `C1`, `C2` are used to run the CH32V003 at 3.3V.  For USB it should not be run beyond 3.6V.
- * `R2`, `R3` 5.1k resistors are only needed if using a type C connector.  If using a USB C host the host will not provide power without these.
+ * `R2`, `R3` 5.1k resistors are only needed if using a type C connector and you want the host to provide 5V power.
 
 It even supports the SOIC-8 - see this thread: https://github.com/cnlohr/rv003usb/issues/25#issuecomment-1779130408
 
 Optionally 33 or 47 ohm resistors may be placed in-series with D+ and D- to the port to reduce noise and help protect the chip.
 
-† If you initialize bus resets by holding the pins low, it is strongly recommended to add the afore mentioned resistors.
+### It's configurable
+
+The Pins (Port and GPIO number) used for USB are configured in `usb_config.h`.
+
+~~~C
+#define USB_PORT D // [A,C,D] GPIO Port to use
+#define USB_DP 3   // [0-4] GPIO Number for USB D+ Pin
+#define USB_DM 4   // [0-4] GPIO Number for USB D- Pin
+#define USB_DPU 5  // [0-7] GPIO for feeding the 1.5k Pull-Up on USB D- Pin; Comment out if not used / tied to 3V3!
+~~~
+
+All configured pins need to be on the same GPIO port.
+
+> [!CAUTION]
+> Only GPIOs 0-4 can be used for USB D+/D- due to limits of the [c.andi](https://msyksphinz-self.github.io/riscv-isadoc/html/rvc.html#c-andi) instruction which can only hold a 5 bit value. 
+> You **cannot use** PC5-PC7 and PD5-PD7 for D+/D-!
+
+A 1,5k pull-up on D- is used to signal the presence of a USB low-speed device on the bus. `USB_DPU` is designed to control this pull-up, but this is optional. You have three options here:
+
+1. Use `USB_DPU` to let RV003USB controll the GPIO. You're limited to using the same port as for D+/D-.
+2. Comment out `USB_DPU` and tie the pull-up to 3V3. This frees a GPIO completely and signals device presence constantly. 
+3. Comment out `USB_DPU` and tie it to a GPIO of your choice - even on a different port. You have to signal device presence in your own user-code though.
+
+Even with the pull-up tied to 3V3 you can trigger a USB re-enumeration by pulsing D- low in user-code. Add the otherwise optional 33/47 ohm inline resistors on D+/D- if you plan on doing this!
+
+See [bootloader](bootloader) for additional considerations on the pin configuration if you plan to use the USB bootloader!
+
+> [!NOTE]
+> Use `make clean` before `make` whenever you change the configuration in `usb_config.h`
+
 
 ### It's got demos!
 
@@ -66,6 +91,10 @@ Note: CDC In windows likely CAN work, but I can't figure out how to do it.  Linu
 ### Care surrounding interrupts and critical sections.
 
 You are allowed to use interrupts and have critical sections, however, you should keep critical sections to approximately 40 or fewer cycles if possible.  Additionally if you are going to be using interrupts that will take longer than about 40 cycles to execute, you must enable preemption on that interrup.  For an example of how that works you can check the ws2812b SPI DMA driver in ch32v003fun.  The external pin-chane-interrupt **must** be the highest priority. And it **must never** be preempted.  While it's OK to have a short delay before it is fired, interrupting the USB reception code mid-transfer is prohibited.
+
+### Modifying headers / `usb_config.h`
+
+Note that if you change the pin assignments for your custom hardware in `usb_config.h`, you will need to run `make clean` afterwards (and then run `make`).
 
 ## It's still in beta.
 

--- a/bootloader/README.md
+++ b/bootloader/README.md
@@ -1,0 +1,72 @@
+# Bootloader
+
+The CH32V003 features 1920 byte additional space for an optional bootloader that runs before your regular code.
+
+This code implements a bootloader that enumerates as USB HID device (so no drivers are needed) and allows for flashing the regular code via USB using a custom version of [minichlink](https://github.com/cnlohr/ch32v003fun/tree/master/minichlink). This means you need a dedicated programmer like the Link-E only once to flash the bootloader. After that, firmware updates can simply be flashed via USB.
+
+By now, you can't update the bootloader using itself and minichlink - you can only flash regular user code.
+
+By default, the bootloader is active for the first ~5s after power-up, then user-code is started. But this boot-mode is highly configurable and can also be triggered by a boot button or USB Host detection instead.
+
+## Compiled size
+When you compile the bootloader, you'll notice that its size is almost 1920 Bytes and thus fills the available space almost completely. The following configuration changes, but also even just the GPIO pin numbers used, change the size of the compiled code and may cause it to exceed the 1920 bytes. So you need to do some trade-offs with the overall pin and boot-mode configuration!
+
+## Configuration
+
+The configuration is done via #defines in `bootloader.c`. See the file for all possible configurations.
+
+### Boot-Modes
+
+#### Timeout
+
+By default, the bootloader is active on every power-up for ~5s and then boots user code if no communication was present. The timeout can be configured.
+
+~~~c
+// Basic timout on power-up
+#define BOOTLOADER_TIMEOUT_PWR 67 // 67 ticks ~= 5s
+~~~
+
+#### USB Host detection and timout
+
+The bootloader can detect the presence of a USB host (not a charger) and adapt the timout in that case. This is useful for devices that are often switched on but usually not connected to a USB Host (e.g. only for firmware updated). Here you want a really short timeout for the bootloader that is only extended if a USB host is detected, giving you a fast/responsive user experience when the devices is powerd on via a charger or battery.
+
+~~~c
+// Stay in bootloader forever if USB host is detected within 3 ticks (~225ms) after power-up, otherwise boot user code
+#define BOOTLOADER_TIMEOUT_PWR 3
+#define BOOTLOADER_TIMEOUT_USB 0
+~~~
+
+~~~c
+// Stay in bootloader for 130 ticks (~10s) if USB host is detected within 3 ticks (~225ms) after power-up, otherwise boot user code
+#define BOOTLOADER_TIMEOUT_PWR 3
+#define BOOTLOADER_TIMEOUT_USB 130
+~~~
+
+#### Boot-Button
+
+A button (any high/low signal) can be used to trigger the bootloader on power-up. The GPIO for the button can be configured, as well as the trigger level and optional internal pull-up/down resistor.
+Using a button you have to press while powering on the device is usually the best option for devices that are powerd by and regularly used with USB host ports - e.g. devices implementing USB HID functionality.
+
+~~~c
+// Boot-Button connected between GND and D2
+#define BOOTLOADER_BTN_PORT D
+#define BOOTLOADER_BTN_PIN 2
+#define BOOTLOADER_BTN_TRIG_LEVEL 0 // 1 = HIGH; 0 = LOW
+#define BOOTLOADER_BTN_PULL 1 // 1 = Pull-Up; 0 = Pull-Down; Optional, comment out for floating input
+// BOOTLOADER_TIMEOUT_PWR 67
+~~~
+
+While you can, in theory, combine the boot button with the timeout and even USB host detection, this will cause the bootloader to exceed its size and result in a compile error. So disabling the timout by commenting out `BOOTLOADER_TIMEOUT_PWR` is recommended.
+
+### USB Pins
+As for all RV003USB projects, the pins are configured in `usb_config.h` - see [main Readme](../) for this. However, there are additional considerations to take into account:
+
+1. As explaned above, the GPIOs used may change the compiled code size. If you need a feature like the USB Host detection, but the code gets too big, try changing the GPIOs.
+2. Not configuring `USB_DPU` saves additional bytes but requires you to power the pull-up on D- via 3V3 constantly (or other means) to get enumerated.
+3. Having the Bootloader Button on the same port as the USB saves additional bytes
+4. If your regular user code does not use the USB stack, you may want to be able to turn off the pull-up on D-. This causes the device to disconnect properly. Otherwise the USB device will keep sowing up but be unresponsive.
+5. If your user code also uses the USB stack, you must force a re-enumeration after switching from bootloader to usercode by pulsing D- low. This is easy with `USB_DPU` used. But with the pull-up fixed to 3V3, a re-enumeration can still be triggered by forcing `USB_DM` low for a moment before initializing USB in user code. But you really want to add the 33 ohm in series resistors in that case.
+
+## USB Troubleshooting
+
+The bootloader should enumerate as HID device with `VID:1209` and `PID:B003` by default. Use `lsusb` on linux/mac or `wmic path Win32_PnPEntity where "DeviceID like 'USB%'" get Caption, DeviceID` on windows to list USB devices. On Windows [USBLogView](https://www.nirsoft.net/utils/usb_log_view.html) and [USBView](https://learn.microsoft.com/windows-hardware/drivers/debugger/usbview) are also helpful tools.

--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -181,10 +181,10 @@ int main()
 		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DM) | 
 		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DP);
 
-	// Configure USB_DP (D-) as an interrupt on falling edge.
-	AFIO->EXTICR = LOCAL_EXP(GPIO_PortSourceGPIO,USB_PORT)<<(USB_DP*2); // Configure EXTI interrupt for USB_DP
-	EXTI->INTENR = 1<<USB_DP; // Enable EXTI interrupt
-	EXTI->FTENR = 1<<USB_DP;  // Enable falling edge trigger for USB_DP (D-)
+	// Configure USB_DM (D-) as an interrupt on falling edge.
+	AFIO->EXTICR = LOCAL_EXP(GPIO_PortSourceGPIO,USB_PORT)<<(USB_DM*2); // Configure EXTI interrupt for USB_DM
+	EXTI->INTENR = 1<<USB_DM; // Enable EXTI interrupt
+	EXTI->FTENR = 1<<USB_DM;  // Enable falling edge trigger for USB_DM (D-)
 
 #if defined(BOOTLOADER_BTN_PORT) && defined(BOOTLOADER_BTN_TRIG_LEVEL) && defined(BOOTLOADER_BTN_PIN)
 	#if BOOTLOADER_BTN_TRIG_LEVEL == 0

--- a/bootloader/usb_config.h
+++ b/bootloader/usb_config.h
@@ -16,8 +16,8 @@
 	PC4 D-_PU
 */
 
-#define USB_DM 3 // USB_DM is the physical USB D+ Pin!
-#define USB_DP 4 // USB_DP is the physical USB D- Pin!
+#define USB_DP 3 // USB D+ Pin!
+#define USB_DM 4 // USB D- Pin!
 #define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
 #define USB_PORT D // Pins on PORT A, C or D
 

--- a/bootloader/usb_config.h
+++ b/bootloader/usb_config.h
@@ -1,5 +1,6 @@
 #ifndef _USB_CONFIG_H
 #define _USB_CONFIG_H
+#define _USB_CONFIG_H_VER 2
 
 //Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.  For one, 2.
 #define ENDPOINTS 2

--- a/bootloader/usb_config.h
+++ b/bootloader/usb_config.h
@@ -16,10 +16,10 @@
 	PC4 D-_PU
 */
 
-#define USB_DP 3 // USB D+ Pin!
-#define USB_DM 4 // USB D- Pin!
-#define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
-#define USB_PORT D // Pins on PORT A, C or D
+#define USB_PORT D // [A,C,D] GPIO Port to use
+#define USB_DP 3   // [0-4] GPIO Number for USB D+ Pin
+#define USB_DM 4   // [0-4] GPIO Number for USB D- Pin
+#define USB_DPU 5  // [0-7] GPIO for feeding the 1.5k Pull-Up on USB D- Pin; Comment out if not used / tied to 3V3!
 
 #define RV003USB_OPTIMIZE_FLASH 1
 

--- a/demo_composite_hid/usb_config.h
+++ b/demo_composite_hid/usb_config.h
@@ -4,8 +4,8 @@
 //Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.
 #define ENDPOINTS 3
 
-#define USB_DM 3 // USB_DM is the physical USB D+ Pin!
-#define USB_DP 4 // USB_DP is the physical USB D- Pin!
+#define USB_DP 3 // USB D+ Pin!
+#define USB_DM 4 // USB D- Pin!
 #define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
 #define USB_PORT D // Pins on PORT A, C or D
 

--- a/demo_composite_hid/usb_config.h
+++ b/demo_composite_hid/usb_config.h
@@ -1,5 +1,6 @@
 #ifndef _USB_CONFIG_H
 #define _USB_CONFIG_H
+#define _USB_CONFIG_H_VER 2
 
 //Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.
 #define ENDPOINTS 3

--- a/demo_composite_hid/usb_config.h
+++ b/demo_composite_hid/usb_config.h
@@ -4,10 +4,10 @@
 //Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.
 #define ENDPOINTS 3
 
-#define USB_DP 3 // USB D+ Pin!
-#define USB_DM 4 // USB D- Pin!
-#define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
-#define USB_PORT D // Pins on PORT A, C or D
+#define USB_PORT D // [A,C,D] GPIO Port to use
+#define USB_DP 3   // [0-4] GPIO Number for USB D+ Pin
+#define USB_DM 4   // [0-4] GPIO Number for USB D- Pin
+#define USB_DPU 5  // [0-7] GPIO for feeding the 1.5k Pull-Up on USB D- Pin; Comment out if not used / tied to 3V3!
 
 #define RV003USB_OPTIMIZE_FLASH 1
 #define RV003USB_EVENT_DEBUGGING 0

--- a/demo_gamepad/usb_config.h
+++ b/demo_gamepad/usb_config.h
@@ -4,10 +4,10 @@
 //Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.
 #define ENDPOINTS 2
 
-#define USB_DP 3 // USB D+ Pin!
-#define USB_DM 4 // USB D- Pin!
-#define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
-#define USB_PORT D // Pins on PORT A, C or D
+#define USB_PORT D // [A,C,D] GPIO Port to use
+#define USB_DP 3   // [0-4] GPIO Number for USB D+ Pin
+#define USB_DM 4   // [0-4] GPIO Number for USB D- Pin
+#define USB_DPU 5  // [0-7] GPIO for feeding the 1.5k Pull-Up on USB D- Pin; Comment out if not used / tied to 3V3!
 
 #define RV003USB_OPTIMIZE_FLASH 0
 #define RV003USB_HANDLE_IN_REQUEST 1

--- a/demo_gamepad/usb_config.h
+++ b/demo_gamepad/usb_config.h
@@ -1,5 +1,6 @@
 #ifndef _USB_CONFIG_H
 #define _USB_CONFIG_H
+#define _USB_CONFIG_H_VER 2
 
 //Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.
 #define ENDPOINTS 2

--- a/demo_gamepad/usb_config.h
+++ b/demo_gamepad/usb_config.h
@@ -4,8 +4,8 @@
 //Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.
 #define ENDPOINTS 2
 
-#define USB_DM 3 // USB_DM is the physical USB D+ Pin!
-#define USB_DP 4 // USB_DP is the physical USB D- Pin!
+#define USB_DP 3 // USB D+ Pin!
+#define USB_DM 4 // USB D- Pin!
 #define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
 #define USB_PORT D // Pins on PORT A, C or D
 

--- a/demo_hidapi/usb_config.h
+++ b/demo_hidapi/usb_config.h
@@ -1,5 +1,6 @@
 #ifndef _USB_CONFIG_H
 #define _USB_CONFIG_H
+#define _USB_CONFIG_H_VER 2
 
 //Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.
 #define ENDPOINTS 2

--- a/demo_hidapi/usb_config.h
+++ b/demo_hidapi/usb_config.h
@@ -4,8 +4,8 @@
 //Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.
 #define ENDPOINTS 2
 
-#define USB_DM 3 // USB_DM is the physical USB D+ Pin!
-#define USB_DP 4 // USB_DP is the physical USB D- Pin!
+#define USB_DP 3 // USB D+ Pin!
+#define USB_DM 4 // USB D- Pin!
 #define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
 #define USB_PORT D // Pins on PORT A, C or D
 

--- a/demo_hidapi/usb_config.h
+++ b/demo_hidapi/usb_config.h
@@ -4,10 +4,10 @@
 //Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.
 #define ENDPOINTS 2
 
-#define USB_DP 3 // USB D+ Pin!
-#define USB_DM 4 // USB D- Pin!
-#define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
-#define USB_PORT D // Pins on PORT A, C or D
+#define USB_PORT D // [A,C,D] GPIO Port to use
+#define USB_DP 3   // [0-4] GPIO Number for USB D+ Pin
+#define USB_DM 4   // [0-4] GPIO Number for USB D- Pin
+#define USB_DPU 5  // [0-7] GPIO for feeding the 1.5k Pull-Up on USB D- Pin; Comment out if not used / tied to 3V3!
 
 #define RV003USB_DEBUG_TIMING      0
 #define RV003USB_OPTIMIZE_FLASH    1

--- a/rv003usb/rv003usb.S
+++ b/rv003usb/rv003usb.S
@@ -174,7 +174,7 @@ packet_type_loop:
 	// a0 = 00 for 1 and 11 for 0
 
 	// No CRC for the header.
-	//c.srli a0, USB_DM
+	//c.srli a0, USB_DP
 	//c.addi a0, 1 // 00 -> 1, 11 -> 100
 	//c.andi a0, 1 // If 1, 1 if 0, 0
         c.nop
@@ -421,7 +421,7 @@ interrupt_complete:
 	c.j 1f; 1: // Extra little bit of delay to make sure we don't accidentally false fire.
 
 	la a5, EXTI_BASE + 20
-	li a0, (1<<USB_DP)
+	li a0, (1<<USB_DM)
 	sw a0, 0(a5)
 
 	// Restore stack.
@@ -569,20 +569,20 @@ usb_send_data:
 	// ASAP: Turn the bus around and send our preamble + token.
 	c.lw a4, CFGLR_OFFSET(a5)
 
-	li s1, ~((0b1111<<(USB_DM*4)) | (0b1111<<(USB_DP*4)))
+	li s1, ~((0b1111<<(USB_DP*4)) | (0b1111<<(USB_DM*4)))
 	and a4, s1, a4
 
 	// Convert D+/D- into 2MHz outputs
-	li s1, ((0b0010<<(USB_DM*4)) | (0b0010<<(USB_DP*4)))
+	li s1, ((0b0010<<(USB_DP*4)) | (0b0010<<(USB_DM*4)))
 	or a4, s1, a4
 
-	li s1, (1<<USB_DM) | (1<<(USB_DP+16))
+	li s1, (1<<USB_DP) | (1<<(USB_DM+16))
 	c.sw s1, BSHR_OFFSET(a5)
 
 	//00: Universal push-pull output mode
 	c.sw a4, CFGLR_OFFSET(a5)
 
-	li t1, (1<<USB_DM) | (1<<(USB_DP+16)) | (1<<USB_DP) | (1<<(USB_DM+16));
+	li t1, (1<<USB_DP) | (1<<(USB_DM+16)) | (1<<USB_DM) | (1<<(USB_DP+16));
 
 	SAVE_DEBUG_MARKER( 8 )
 
@@ -787,20 +787,20 @@ no_really_done_sending_data:
 	nx6p3delay( 2, a3 );
 
 	// Need to perform an SE0.
-	li s1, (1<<(USB_DP+16)) | (1<<(USB_DM+16))
+	li s1, (1<<(USB_DM+16)) | (1<<(USB_DP+16))
 	c.sw s1, BSHR_OFFSET(a5)
 
 	nx6p3delay( 7, a3 );
 
-	li s1, (1<<(USB_DP)) | (1<<(USB_DM+16))
+	li s1, (1<<(USB_DM)) | (1<<(USB_DP+16))
 	c.sw s1, BSHR_OFFSET(a5)
 
 	lw s1, CFGLR_OFFSET(a5)
 	// Convert D+/D- into inputs.
-	li a3, ~((0b11<<(USB_DM*4)) | (0b11<<(USB_DP*4)))
+	li a3, ~((0b11<<(USB_DP*4)) | (0b11<<(USB_DM*4)))
 	and s1, a3, s1
 	// 01: Floating input mode.
-	li a3, ((0b01<<(USB_DM*4+2)) | (0b01<<(USB_DP*4+2)))
+	li a3, ((0b01<<(USB_DP*4+2)) | (0b01<<(USB_DM*4+2)))
 	or s1, a3, s1
 	sw s1, CFGLR_OFFSET(a5)
 

--- a/rv003usb/rv003usb.c
+++ b/rv003usb/rv003usb.c
@@ -106,10 +106,10 @@ void usb_setup()
 		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DM) | 
 		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DP);
 
-	// Configure USB_DP (D-) as an interrupt on falling edge.
-	AFIO->EXTICR = LOCAL_EXP(GPIO_PortSourceGPIO,USB_PORT)<<(USB_DP*2); // Configure EXTI interrupt for USB_DP
-	EXTI->INTENR = 1<<USB_DP; // Enable EXTI interrupt
-	EXTI->FTENR = 1<<USB_DP;  // Enable falling edge trigger for USB_DP (D-)
+	// Configure USB_DM (D-) as an interrupt on falling edge.
+	AFIO->EXTICR = LOCAL_EXP(GPIO_PortSourceGPIO,USB_PORT)<<(USB_DM*2); // Configure EXTI interrupt for USB_DM
+	EXTI->INTENR = 1<<USB_DM; // Enable EXTI interrupt
+	EXTI->FTENR = 1<<USB_DM;  // Enable falling edge trigger for USB_DM (D-)
 
 #ifdef USB_DPU
 	// This drives USB_DPU (D- Pull-Up) high, which will tell the host that we are going on-bus.

--- a/rv003usb/rv003usb.h
+++ b/rv003usb/rv003usb.h
@@ -3,6 +3,12 @@
 
 #include "usb_config.h"
 
+// Earlier usb_config.h had USB_DM/USB_DP swapped; Alert user to correct them!
+#if !defined(_USB_CONFIG_H_VER) || _USB_CONFIG_H_VER < 2
+#error 	Your "usb_config.h" is outdated! Please swap USB_DP/USB_DM, \
+		they now reflect the correct signal! \
+		Add "#define _USB_CONFIG_H_VER 2" to suppress this error!
+#endif
 
 #define LOCAL_CONCAT_BASE(A, B) A##B##_BASE
 #define LOCAL_EXP_BASE(A, B) LOCAL_CONCAT_BASE(A,B)


### PR DESCRIPTION
Before this, USB_DP was used for D- and USB_DM was used for D+ due to historical reasons during development of the USB stack. This however is frustratingly confusing, so this should fix it.

It also changes the demos and readme to reflect the change. 

Additional documentation for the bootloader was added.

> [!CAUTION]
> **THIS IS A BREAKING CHANGE** kind of ...

If RV003USB is updated but the old `usb_config.h` is kept untouched, the device will fail to enumerate.

I was considering adding a `#define RV003USB_CONFIG_VERSION 2` to `usb_config.h` and throwing an error in `rv003usb.c` if it's not defined. (or `#define RV003USB_REAL_PIN_NAMES`)

I was also considering adding a red banner (like the one above) to the main readme.

Any thoughts if I should add something like this to alert users?