### PR TITLE
Rename USB_DM/USB_DP to end confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It shows both how to be a normal USB device, as well as how to write programs to
 
 ![Example Schematic](https://raw.githubusercontent.com/cnlohr/rv003usb/master/doc/schematic.png)
 
-The reason why D+/D- is "flipped" from what is listed in `usb_config.h` is because for USB low-speed, the D+/D- lines are swapped. It is frustratingly unintuitive. Also note that if you change the pin assignments for your custom hardware, you will need to run `make clean` after any hardware changes (and then run `make`).
+Note that if you change the pin assignments for your custom hardware, you will need to run `make clean` after any hardware changes (and then run `make`).
 
 As-written you **cannot** use PD6,7 or PC6,7 in any combination with the USB stack.  You must use other pins.  Sorry, let me know if you find a way.
 

--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -157,9 +157,9 @@ int main()
 		0x44444444 // reset value (all input)
 #endif
 		// Reset the USB Pins
-		& ~( 0xF<<(4*USB_DM) | 0xF<<(4*USB_DP) 
-		#ifdef USB_DPU
-			| 0xF<<(4*USB_DPU)
+		& ~( 0xF<<(4*USB_PIN_DP) | 0xF<<(4*USB_PIN_DM) 
+		#ifdef USB_PIN_DPU
+			| 0xF<<(4*USB_PIN_DPU)
 		#endif
 		// reset Bootloader Btn Pin
 		#if defined(BOOTLOADER_BTN_PORT) && PORTID_EQUALS(BOOTLOADER_BTN_PORT,USB_PORT)
@@ -168,8 +168,8 @@ int main()
 		)
 	) |
 	// Configure the USB Pins
-#ifdef USB_DPU
-		(GPIO_Speed_50MHz | GPIO_CNF_OUT_PP)<<(4*USB_DPU) |
+#ifdef USB_PIN_DPU
+		(GPIO_Speed_50MHz | GPIO_CNF_OUT_PP)<<(4*USB_PIN_DPU) |
 #endif
 #if defined(BOOTLOADER_BTN_PORT) && PORTID_EQUALS(BOOTLOADER_BTN_PORT,USB_PORT)
 	#if defined(BOOTLOADER_BTN_PULL)
@@ -178,13 +178,13 @@ int main()
 		(GPIO_Speed_In | GPIO_CNF_IN_FLOATING)<<(4*BOOTLOADER_BTN_PIN) | 
 	#endif
 #endif
-		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DM) | 
-		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DP);
+		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_PIN_DP) | 
+		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_PIN_DM);
 
-	// Configure USB_DP (D-) as an interrupt on falling edge.
-	AFIO->EXTICR = LOCAL_EXP(GPIO_PortSourceGPIO,USB_PORT)<<(USB_DP*2); // Configure EXTI interrupt for USB_DP
-	EXTI->INTENR = 1<<USB_DP; // Enable EXTI interrupt
-	EXTI->FTENR = 1<<USB_DP;  // Enable falling edge trigger for USB_DP (D-)
+	// Configure USB_PIN_DM (D-) as an interrupt on falling edge.
+	AFIO->EXTICR = LOCAL_EXP(GPIO_PortSourceGPIO,USB_PORT)<<(USB_PIN_DM*2); // Configure EXTI interrupt for USB_PIN_DM
+	EXTI->INTENR = 1<<USB_PIN_DM; // Enable EXTI interrupt
+	EXTI->FTENR = 1<<USB_PIN_DM;  // Enable falling edge trigger for USB_PIN_DM (D-)
 
 #if defined(BOOTLOADER_BTN_PORT) && defined(BOOTLOADER_BTN_TRIG_LEVEL) && defined(BOOTLOADER_BTN_PIN)
 	#if BOOTLOADER_BTN_TRIG_LEVEL == 0
@@ -194,9 +194,9 @@ int main()
 	#endif
 #endif
 
-#ifdef USB_DPU
-	// This drives USB_DPU (D- Pull-Up) high, which will tell the host that we are going on-bus.
-	LOCAL_EXP(GPIO,USB_PORT)->BSHR = 1<<USB_DPU;
+#ifdef USB_PIN_DPU
+	// This drives USB_PIN_DPU (D- Pull-Up) high, which will tell the host that we are going on-bus.
+	LOCAL_EXP(GPIO,USB_PORT)->BSHR = 1<<USB_PIN_DPU;
 #endif
 
 	// enable interrupt

--- a/bootloader/usb_config.h
+++ b/bootloader/usb_config.h
@@ -16,9 +16,9 @@
 	PC4 D-_PU
 */
 
-#define USB_DM 3 // USB_DM is the physical USB D+ Pin!
-#define USB_DP 4 // USB_DP is the physical USB D- Pin!
-#define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
+#define USB_PIN_DP 3 // USB_PIN_DP is the physical USB D+ Pin!
+#define USB_PIN_DM 4 // USB_PIN_DM is the physical USB D- Pin!
+#define USB_PIN_DPU 5 // USB_PIN_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
 #define USB_PORT D // Pins on PORT A, C or D
 
 #define RV003USB_OPTIMIZE_FLASH 1

--- a/demo_composite_hid/usb_config.h
+++ b/demo_composite_hid/usb_config.h
@@ -4,9 +4,9 @@
 //Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.
 #define ENDPOINTS 3
 
-#define USB_DM 3 // USB_DM is the physical USB D+ Pin!
-#define USB_DP 4 // USB_DP is the physical USB D- Pin!
-#define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
+#define USB_PIN_DP 3 // USB_PIN_DP is the physical USB D+ Pin!
+#define USB_PIN_DM 4 // USB_PIN_DM is the physical USB D- Pin!
+#define USB_PIN_DPU 5 // USB_PIN_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
 #define USB_PORT D // Pins on PORT A, C or D
 
 #define RV003USB_OPTIMIZE_FLASH 1

--- a/demo_gamepad/usb_config.h
+++ b/demo_gamepad/usb_config.h
@@ -4,9 +4,9 @@
 //Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.
 #define ENDPOINTS 2
 
-#define USB_DM 3 // USB_DM is the physical USB D+ Pin!
-#define USB_DP 4 // USB_DP is the physical USB D- Pin!
-#define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
+#define USB_PIN_DP 3 // USB_PIN_DP is the physical USB D+ Pin!
+#define USB_PIN_DM 4 // USB_PIN_DM is the physical USB D- Pin!
+#define USB_PIN_DPU 5 // USB_PIN_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
 #define USB_PORT D // Pins on PORT A, C or D
 
 #define RV003USB_OPTIMIZE_FLASH 0

--- a/demo_hidapi/usb_config.h
+++ b/demo_hidapi/usb_config.h
@@ -4,9 +4,9 @@
 //Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.
 #define ENDPOINTS 2
 
-#define USB_DM 3 // USB_DM is the physical USB D+ Pin!
-#define USB_DP 4 // USB_DP is the physical USB D- Pin!
-#define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
+#define USB_PIN_DP 3 // USB_PIN_DP is the physical USB D+ Pin!
+#define USB_PIN_DM 4 // USB_PIN_DM is the physical USB D- Pin!
+#define USB_PIN_DPU 5 // USB_PIN_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
 #define USB_PORT D // Pins on PORT A, C or D
 
 #define RV003USB_DEBUG_TIMING      0

--- a/rv003usb/rv003usb.S
+++ b/rv003usb/rv003usb.S
@@ -174,7 +174,7 @@ packet_type_loop:
 	// a0 = 00 for 1 and 11 for 0
 
 	// No CRC for the header.
-	//c.srli a0, USB_DM
+	//c.srli a0, USB_PIN_DP
 	//c.addi a0, 1 // 00 -> 1, 11 -> 100
 	//c.andi a0, 1 // If 1, 1 if 0, 0
         c.nop
@@ -421,7 +421,7 @@ interrupt_complete:
 	c.j 1f; 1: // Extra little bit of delay to make sure we don't accidentally false fire.
 
 	la a5, EXTI_BASE + 20
-	li a0, (1<<USB_DP)
+	li a0, (1<<USB_PIN_DM)
 	sw a0, 0(a5)
 
 	// Restore stack.
@@ -569,20 +569,20 @@ usb_send_data:
 	// ASAP: Turn the bus around and send our preamble + token.
 	c.lw a4, CFGLR_OFFSET(a5)
 
-	li s1, ~((0b1111<<(USB_DM*4)) | (0b1111<<(USB_DP*4)))
+	li s1, ~((0b1111<<(USB_PIN_DP*4)) | (0b1111<<(USB_PIN_DM*4)))
 	and a4, s1, a4
 
 	// Convert D+/D- into 2MHz outputs
-	li s1, ((0b0010<<(USB_DM*4)) | (0b0010<<(USB_DP*4)))
+	li s1, ((0b0010<<(USB_PIN_DP*4)) | (0b0010<<(USB_PIN_DM*4)))
 	or a4, s1, a4
 
-	li s1, (1<<USB_DM) | (1<<(USB_DP+16))
+	li s1, (1<<USB_PIN_DP) | (1<<(USB_PIN_DM+16))
 	c.sw s1, BSHR_OFFSET(a5)
 
 	//00: Universal push-pull output mode
 	c.sw a4, CFGLR_OFFSET(a5)
 
-	li t1, (1<<USB_DM) | (1<<(USB_DP+16)) | (1<<USB_DP) | (1<<(USB_DM+16));
+	li t1, (1<<USB_PIN_DP) | (1<<(USB_PIN_DM+16)) | (1<<USB_PIN_DM) | (1<<(USB_PIN_DP+16));
 
 	SAVE_DEBUG_MARKER( 8 )
 
@@ -787,20 +787,20 @@ no_really_done_sending_data:
 	nx6p3delay( 2, a3 );
 
 	// Need to perform an SE0.
-	li s1, (1<<(USB_DP+16)) | (1<<(USB_DM+16))
+	li s1, (1<<(USB_PIN_DM+16)) | (1<<(USB_PIN_DP+16))
 	c.sw s1, BSHR_OFFSET(a5)
 
 	nx6p3delay( 7, a3 );
 
-	li s1, (1<<(USB_DP)) | (1<<(USB_DM+16))
+	li s1, (1<<(USB_PIN_DM)) | (1<<(USB_PIN_DP+16))
 	c.sw s1, BSHR_OFFSET(a5)
 
 	lw s1, CFGLR_OFFSET(a5)
 	// Convert D+/D- into inputs.
-	li a3, ~((0b11<<(USB_DM*4)) | (0b11<<(USB_DP*4)))
+	li a3, ~((0b11<<(USB_PIN_DP*4)) | (0b11<<(USB_PIN_DM*4)))
 	and s1, a3, s1
 	// 01: Floating input mode.
-	li a3, ((0b01<<(USB_DM*4+2)) | (0b01<<(USB_DP*4+2)))
+	li a3, ((0b01<<(USB_PIN_DP*4+2)) | (0b01<<(USB_PIN_DM*4+2)))
 	or s1, a3, s1
 	sw s1, CFGLR_OFFSET(a5)
 

--- a/rv003usb/rv003usb.c
+++ b/rv003usb/rv003usb.c
@@ -94,26 +94,26 @@ void usb_setup()
 	// GPIO Setup
 	LOCAL_EXP( GPIO, USB_PORT )->CFGLR = 
 		( LOCAL_EXP( GPIO, USB_PORT )->CFGLR & 
-			(~( ( ( 0xf << (USB_DM*4)) | ( 0xf << (USB_DP*4)) 
-#ifdef USB_DPU
-				| ( 0xf << (USB_DPU*4)) 
+			(~( ( ( 0xf << (USB_PIN_DP*4)) | ( 0xf << (USB_PIN_DM*4)) 
+#ifdef USB_PIN_DPU
+				| ( 0xf << (USB_PIN_DPU*4)) 
 #endif
 			) )) )
 		 |
-#ifdef USB_DPU
-		(GPIO_Speed_50MHz | GPIO_CNF_OUT_PP)<<(4*USB_DPU) |
+#ifdef USB_PIN_DPU
+		(GPIO_Speed_50MHz | GPIO_CNF_OUT_PP)<<(4*USB_PIN_DPU) |
 #endif
-		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DM) | 
-		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_DP);
+		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_PIN_DP) | 
+		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_PIN_DM);
 
-	// Configure USB_DP (D-) as an interrupt on falling edge.
-	AFIO->EXTICR = LOCAL_EXP(GPIO_PortSourceGPIO,USB_PORT)<<(USB_DP*2); // Configure EXTI interrupt for USB_DP
-	EXTI->INTENR = 1<<USB_DP; // Enable EXTI interrupt
-	EXTI->FTENR = 1<<USB_DP;  // Enable falling edge trigger for USB_DP (D-)
+	// Configure USB_PIN_DM (D-) as an interrupt on falling edge.
+	AFIO->EXTICR = LOCAL_EXP(GPIO_PortSourceGPIO,USB_PORT)<<(USB_PIN_DM*2); // Configure EXTI interrupt for USB_PIN_DM
+	EXTI->INTENR = 1<<USB_PIN_DM; // Enable EXTI interrupt
+	EXTI->FTENR = 1<<USB_PIN_DM;  // Enable falling edge trigger for USB_PIN_DM (D-)
 
-#ifdef USB_DPU
-	// This drives USB_DPU (D- Pull-Up) high, which will tell the host that we are going on-bus.
-	LOCAL_EXP(GPIO,USB_PORT)->BSHR = 1<<USB_DPU;
+#ifdef USB_PIN_DPU
+	// This drives USB_PIN_DPU (D- Pull-Up) high, which will tell the host that we are going on-bus.
+	LOCAL_EXP(GPIO,USB_PORT)->BSHR = 1<<USB_PIN_DPU;
 #endif
 
 	// enable interrupt

--- a/rv003usb/rv003usb.h
+++ b/rv003usb/rv003usb.h
@@ -88,7 +88,7 @@ uint32_t * GetUEvent();
 // Packet Type + 8 + CRC + Buffer
 #define USB_BUFFER_SIZE 12
 
-#define USB_DMASK ((1<<(USB_DM)) | 1<<(USB_DP))
+#define USB_DMASK ((1<<(USB_PIN_DP)) | 1<<(USB_PIN_DM))
 
 #ifdef  RV003USB_OPTIMIZE_FLASH
 #define MY_ADDRESS_OFFSET_BYTES 4

--- a/rv003usb/rv003usb.h
+++ b/rv003usb/rv003usb.h
@@ -3,6 +3,15 @@
 
 #include "usb_config.h"
 
+// Fallback and issue warning for users with the swapped pin assignments of previous versions
+#if defined(USB_DM) && defined(USB_DP)
+#warning "You usb_config.h is outdated. Please use USB_PIN_DP, USB_PIN_DM and USB_PIN_DPU instead with their respective signal (no swapping!)"
+#define USB_PIN_DM USB_DP
+#define USB_PIN_DP USB_DM
+#if defined(USB_DPU)
+#define USB_PIN_DPU USB_DPU
+#endif // DPU
+#endif // DM/DP
 
 #define LOCAL_CONCAT_BASE(A, B) A##B##_BASE
 #define LOCAL_EXP_BASE(A, B) LOCAL_CONCAT_BASE(A,B)

--- a/rv003usb/rv003usb.h
+++ b/rv003usb/rv003usb.h
@@ -4,14 +4,14 @@
 #include "usb_config.h"
 
 // Fallback and issue warning for users with the swapped pin assignments of previous versions
-#if defined(USB_DM) && defined(USB_DP)
+#if defined(USB_DM) || defined(USB_DP)
 #warning "You usb_config.h is outdated. Please use USB_PIN_DP, USB_PIN_DM and USB_PIN_DPU instead with their respective signal (no swapping!)"
 #define USB_PIN_DM USB_DP
 #define USB_PIN_DP USB_DM
+#endif
 #if defined(USB_DPU)
 #define USB_PIN_DPU USB_DPU
-#endif // DPU
-#endif // DM/DP
+#endif
 
 #define LOCAL_CONCAT_BASE(A, B) A##B##_BASE
 #define LOCAL_EXP_BASE(A, B) LOCAL_CONCAT_BASE(A,B)

--- a/testing/cdc_exp/usb_config.h
+++ b/testing/cdc_exp/usb_config.h
@@ -4,9 +4,9 @@
 //Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.
 #define ENDPOINTS 4
 
-#define USB_DM 3
-#define USB_DP 4
-#define USB_DPU 5
+#define USB_PIN_DP 3
+#define USB_PIN_DM 4
+#define USB_PIN_DPU 5
 #define USB_PORT D
 
 #define RV003USB_HANDLE_IN_REQUEST 1

--- a/testing/demo_midi/usb_config.h
+++ b/testing/demo_midi/usb_config.h
@@ -4,9 +4,9 @@
 //Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.
 #define ENDPOINTS 3
 
-#define USB_DM 3
-#define USB_DP 4
-#define USB_DPU 5
+#define USB_PIN_DP 3
+#define USB_PIN_DM 4
+#define USB_PIN_DPU 5
 #define USB_PORT D
 
 #define RV003USB_EVENT_DEBUGGING 1

--- a/testing/demo_touchpad/README.md
+++ b/testing/demo_touchpad/README.md
@@ -15,11 +15,11 @@ Connected to touch pads,
 
 It maps left/right and up/down to axes, and all the buttons to buttons.
 
-Assuming USB is as follows:  (remember, DM/DP are flipped)
+Assuming USB is as follows:
 ```
-#define USB_DM 2
-#define USB_DP 1
-#define USB_DPU 0
+#define USB_PIN_DP 2
+#define USB_PIN_DM 1
+#define USB_PIN_DPU 0
 #define USB_PORT C
 ```
 

--- a/testing/demo_touchpad/usb_config.h
+++ b/testing/demo_touchpad/usb_config.h
@@ -4,9 +4,9 @@
 //Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.
 #define ENDPOINTS 2
 
-#define USB_DM 2
-#define USB_DP 1
-#define USB_DPU 0
+#define USB_PIN_DP 2
+#define USB_PIN_DM 1
+#define USB_PIN_DPU 0
 #define USB_PORT C
 
 #define RV003USB_DEBUG_TIMING      0

--- a/testing/sandbox/usb_config.h
+++ b/testing/sandbox/usb_config.h
@@ -4,9 +4,9 @@
 //Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.
 #define ENDPOINTS 4
 
-#define USB_DM 3
-#define USB_DP 4
-#define USB_DPU 5
+#define USB_PIN_DP 3
+#define USB_PIN_DM 4
+#define USB_PIN_DPU 5
 #define USB_PORT D
 
 #define RV003USB_OPTIMIZE_FLASH 1

--- a/testing/test_ethernet/usb_config.h
+++ b/testing/test_ethernet/usb_config.h
@@ -4,9 +4,9 @@
 //Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.
 #define ENDPOINTS 4
 
-#define USB_DM 3
-#define USB_DP 4
-#define USB_DPU 5
+#define USB_PIN_DP 3
+#define USB_PIN_DM 4
+#define USB_PIN_DPU 5
 #define USB_PORT D
 
 #define RV003USB_EVENT_DEBUGGING     1


### PR DESCRIPTION
Before this, USB_DP was used for D- and USB_DM was used for D+ due to historical reasons during development of the USB stack. This however is frustratingly confusing, so this should fix it.

This renames `USB_DM` to `USB_PIN_DP`, `USB_DP` to `USB_PIN_DM` and `USB_DPU` to `USB_PIN_DPU` (for consistency).
The changes include a fallback so previous code will still compile fine but issue a warning.

Users with
~~~c
#define USB_DM 3 // USB_DM is the physical USB D+ Pin!
#define USB_DP 4 // USB_DP is the physical USB D- Pin!
#define USB_DPU 5 // USB_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
#define USB_PORT D // Pins on PORT A, C or D
~~~
are encouraged to switch to
~~~c
#define USB_PIN_DP 3 // USB_PIN_DP is the physical USB D+ Pin!
#define USB_PIN_DM 4 // USB_PIN_DM is the physical USB D- Pin!
#define USB_PIN_DPU 5 // USB_PIN_DPU feeds the 1.5K Pull-Up on USB D- Pin! Comment out if not used / tied to 3V3!
#define USB_PORT D // Pins on PORT A, C or D
~~~

Users that have not switched yet will get a compiler warning
> **Warning**: #warning "You usb_config.h is outdated. Please use USB_PIN_DP, USB_PIN_DM and USB_PIN_DPU instead with their respective signal (no swapping!)"

This replaces #44 due to user feedback