### PR TITLE
error if FUNCONF_SYSTICK_USE_HCLK is not set

### DIFF
--- a/rv003usb/rv003usb.h
+++ b/rv003usb/rv003usb.h
@@ -13,6 +13,10 @@
 #define USB_PIN_DPU USB_DPU
 #endif
 
+#if !defined(FUNCONF_SYSTICK_USE_HCLK) || !FUNCONF_SYSTICK_USE_HCLK
+#error "RV003USB requires #define FUNCONF_SYSTICK_USE_HCLK 1; see funconfig.h"
+#endif
+
 #define LOCAL_CONCAT_BASE(A, B) A##B##_BASE
 #define LOCAL_EXP_BASE(A, B) LOCAL_CONCAT_BASE(A,B)
 


### PR DESCRIPTION
Throw an error if FUNCONF_SYSTICK_USE_HCLK is not set. FUNCONF_SYSTICK_USE_HCLK is required for USB to work.
Fixes #36 