### PR TITLE
Revert "throw error if FUNCONF_SYSTICK_USE_HCLK is not set"

### DIFF
--- a/rv003usb/rv003usb.h
+++ b/rv003usb/rv003usb.h
@@ -13,10 +13,6 @@
 #define USB_PIN_DPU USB_DPU
 #endif
 
-#if !defined(FUNCONF_SYSTICK_USE_HCLK) || !FUNCONF_SYSTICK_USE_HCLK
-#error "RV003USB requires #define FUNCONF_SYSTICK_USE_HCLK 1; see funconfig.h"
-#endif
-
 #define LOCAL_CONCAT_BASE(A, B) A##B##_BASE
 #define LOCAL_EXP_BASE(A, B) LOCAL_CONCAT_BASE(A,B)
 


### PR DESCRIPTION
This reverts commit d79484df60a18f5767588498d3e66512530e8478.

The commit builds with an error in all examples