### PR TITLE
make port configurable for DPU pin

### DIFF
--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -202,7 +202,9 @@ int main()
 #if defined(USB_PIN_DPU) && !defined(USB_DPU_PORT)
 	// This drives USB_PIN_DPU (D- Pull-Up) high, which will tell the host that we are going on-bus.
 	LOCAL_EXP(GPIO,USB_PORT)->BSHR = 1<<USB_PIN_DPU;
-#else
+#endif
+
+#if defined(USB_PIN_DPU) && defined(USB_DPU_PORT)
 	LOCAL_EXP(GPIO,USB_DPU_PORT)->BSHR = 1<<USB_PIN_DPU;
 #endif
 

--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -158,7 +158,7 @@ int main()
 #endif
 		// Reset the USB Pins
 		& ~( 0xF<<(4*USB_PIN_DP) | 0xF<<(4*USB_PIN_DM) 
-		#ifdef USB_PIN_DPU
+		#if defined(USB_PIN_DPU) && (PORTID_EQUALS(USB_DPU_PORT,USB_PORT) || !defined(USB_DPU_PORT))
 			| 0xF<<(4*USB_PIN_DPU)
 		#endif
 		// reset Bootloader Btn Pin
@@ -181,6 +181,11 @@ int main()
 		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_PIN_DP) | 
 		(GPIO_Speed_In | GPIO_CNF_IN_PUPD)<<(4*USB_PIN_DM);
 
+#if defined(USB_DPU_PORT) && !PORTID_EQUALS(USB_DPU_PORT,USB_PORT)
+	LOCAL_EXP(GPIO, USB_DPU_PORT)->CFGLR &= ~(0xf<<(4*USB_PIN_DPU));
+   LOCAL_EXP(GPIO, USB_DPU_PORT)->CFGLR |= (GPIO_Speed_50MHz | GPIO_CNF_OUT_PP)<<(4*USB_PIN_DPU);
+#endif
+
 	// Configure USB_PIN_DM (D-) as an interrupt on falling edge.
 	AFIO->EXTICR = LOCAL_EXP(GPIO_PortSourceGPIO,USB_PORT)<<(USB_PIN_DM*2); // Configure EXTI interrupt for USB_PIN_DM
 	EXTI->INTENR = 1<<USB_PIN_DM; // Enable EXTI interrupt
@@ -194,9 +199,11 @@ int main()
 	#endif
 #endif
 
-#ifdef USB_PIN_DPU
+#if defined(USB_PIN_DPU) && !defined(USB_DPU_PORT)
 	// This drives USB_PIN_DPU (D- Pull-Up) high, which will tell the host that we are going on-bus.
 	LOCAL_EXP(GPIO,USB_PORT)->BSHR = 1<<USB_PIN_DPU;
+#else
+	LOCAL_EXP(GPIO,USB_DPU_PORT)->BSHR = 1<<USB_PIN_DPU;
 #endif
 
 	// enable interrupt

--- a/bootloader/usb_config.h
+++ b/bootloader/usb_config.h
@@ -19,6 +19,7 @@
 #define USB_PORT D     // [A,C,D] GPIO Port to use with D+, D- and DPU
 #define USB_PIN_DP 3   // [0-4] GPIO Number for USB D+ Pin
 #define USB_PIN_DM 4   // [0-4] GPIO Number for USB D- Pin
+//#define USB_PORT_DPU A  // [A,C,D] Override GPIO Port for DPU
 #define USB_PIN_DPU 5  // [0-7] GPIO for feeding the 1.5k Pull-Up on USB D- Pin; Comment out if not used / tied to 3V3!
 
 #define RV003USB_OPTIMIZE_FLASH 1


### PR DESCRIPTION
This PR makes the port for the DPU pin configurable. For example, I'm using PA for USB DP/DN and PD for DPU. I tried to keep it backwards compatible so no changes are needed in usb_config.h unless the DPU port needs to be changed.