### PR TITLE
Fix bootloader.c for use with button

### DIFF
--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -221,6 +221,7 @@ int main()
 	int32_t localpad = BOOTLOADER_TIMEOUT_BASE * BOOTLOADER_TIMEOUT_PWR;
 	while(1)
 	{
+#if !(BOOTLOADER_TIMEOUT_PWR == 0) && defined(BOOTLOADER_BTN_PIN)
 		if( localpad < 0 )
 		{
 			if( ++localpad == 0 )
@@ -246,6 +247,7 @@ int main()
 	#endif
 #endif
 		}
+#endif
 		if( localpad > 0 )
 		{
 			if( --localpad == 0 )


### PR DESCRIPTION
This helps to fit compiled binary in 1920 bytes if using button. Before it was 8 bytes over if you defined a button.