### PR TITLE
Fix #82

### DIFF
--- a/bootloader/configurebootloader/Makefile
+++ b/bootloader/configurebootloader/Makefile
@@ -1,8 +1,9 @@
 all : flash
 
 TARGET:=configurebootloader
+TARGET_MCU?=CH32V003
 
-include ../../ch32v003fun/ch32v003fun/ch32v003fun.mk
+include ../../ch32v003fun/ch32fun/ch32fun.mk
 
 flash : cv_flash
 clean : cv_clean

--- a/bootloader/configurebootloader/configurebootloader.c
+++ b/bootloader/configurebootloader/configurebootloader.c
@@ -13,7 +13,7 @@
  * microcontroller manufactured by Nanjing Qinheng Microelectronics.
  *******************************************************************************/
 
-#include "ch32v003fun.h"
+#include "ch32fun.h"
 #include <stdio.h>
 
 uint32_t count;


### PR DESCRIPTION
This has been tested today with a tssop20 ch32v003.

I've confirmed that it builds and flashes using the esp32s2funprog programmer. I've confirmed that the demo_gamepad example works (it enumerates as a low-speed USB device).

Closes #82 