### PR TITLE
Add abitlity to use free EXTI channels by user code

### DIFF
--- a/demo_exti/Makefile
+++ b/demo_exti/Makefile
@@ -1,0 +1,15 @@
+all : flash
+
+TARGET:=demo_exti
+CH32FUN:=../ch32v003fun/ch32fun
+TARGET_MCU:=CH32V003
+
+ADDITIONAL_C_FILES+=../rv003usb/rv003usb.S ../rv003usb/rv003usb.c
+EXTRA_CFLAGS:=-I../lib -I../rv003usb
+
+include $(CH32FUN)/ch32fun.mk
+
+flash : cv_flash
+clean : cv_clean
+
+

--- a/demo_exti/README.md
+++ b/demo_exti/README.md
@@ -1,0 +1,11 @@
+# Additional EXTI interrupt
+
+This is a copy of hidapi demo with additions to show how to use additional EXTI channels while using rv003usb. Software USB stack is relying heavily on external pin interrupt, this made it impossible to use EXTI for anything else. This example shows how you can add another EXTI channel with simple interrupt handler.
+
+First you need to chose a GPIO for this. Pin number can't be the same as pin number of GPIO that is used for D- of the USB. You need to enable corresponding GPIO peripheral, EXTI channel and set Falling/Rising edge detection for that channel.
+
+Then you need to define ``RV003_ADD_EXTI_MASK`` and ``RV003_ADD_EXTI_HANDLER`` in ``funconfig.h`` or ``usb_config.h``. ``RV003_ADD_EXTI_MASK`` should contain mask of one or more additional EXTI channels, ``RV003_ADD_EXTI_HANDLER`` is where you put your assembly code that will be called at the interrupt, if additional EXTI channel was triggered. For now there is no easy way to compile C code and put it back to .S file, and frankly you better keep the handler as simple as possible. You can use s1, a0, a2, a3, a4 and a5 registers without any additional precautions.
+
+The demo as is uses PC0 to toggle the LED on rising edge as indication of working interrupt on PC7 - EXTI channel 7.
+
+You can use ``testtop`` utility from ``demo_hidapi`` to test that additiona iterrupt code doesn't mess with USB functionality.

--- a/demo_exti/demo_exti.c
+++ b/demo_exti/demo_exti.c
@@ -1,0 +1,145 @@
+#include "ch32fun.h"
+#include <stdio.h>
+#include <string.h>
+#include "rv003usb.h"
+
+#define WSRAW
+#define WS2812B_ALLOW_INTERRUPT_NESTING
+#define WS2812DMA_IMPLEMENTATION
+#define DMALEDS 96 // Provide enough of a buffer things don't get messed up (actually uses 768 bytes)
+#include "ws2812b_dma_spi_led_driver.h"
+
+// Allow reading and writing to the scratchpad via HID control messages.
+uint8_t scratch[255];
+volatile uint8_t start_leds = 0;
+uint8_t ledat;
+
+static uint8_t frame;
+
+volatile uint32_t another_interrupt_flag = 0;
+
+uint32_t WS2812BLEDCallback( int wordno )
+{
+	return ((uint32_t*)scratch)[wordno+1];
+}
+
+void do_tricks() __attribute__((noinline));	// Makes it easier to find assembly of your code in lst
+void do_tricks() {
+	if (another_interrupt_flag != 0) {
+		if (funDigitalRead(PC0)) {
+			funDigitalWrite(PC0, 0);
+		} else {
+			funDigitalWrite(PC0, 1);
+		}
+		another_interrupt_flag = 0;
+	}
+}
+
+int main()
+{
+	SystemInit();
+	Delay_Ms(1); // Ensures USB re-enumeration after bootloader or reset; Spec demand >2.5µs ( TDDIS )
+	usb_setup();
+
+	GPIOD->CFGLR = ( ( GPIOD->CFGLR ) & (~( 0xf << (4*2) )) ) | 
+		(GPIO_Speed_50MHz | GPIO_CNF_OUT_PP)<<(4*2);
+	
+	RCC->APB2PCENR |= RCC_APB2Periph_GPIOC;
+	funPinMode( PC0, GPIO_Speed_10MHz | GPIO_CNF_OUT_PP );
+	funPinMode( PC7, GPIO_CFGLR_IN_PUPD );
+	funDigitalWrite( PC7, 0 );	// Enable pull-down for external interrupt
+	funDigitalWrite( PC0, 1 );	// Pin to toggle for demonstration
+
+	AFIO->EXTICR |= AFIO_EXTICR1_EXTI7_PC;
+	EXTI->INTENR |= EXTI_INTENR_MR7; // Enable EXT7
+	EXTI->RTENR |= EXTI_RTENR_TR7;  // Rising edge trigger
+
+	WS2812BDMAInit();// Use DMA and SPI to stream out WS2812B LED Data via the MOSI pin.
+	Delay_Ms(500);
+
+	while(1)
+	{
+		do_tricks();
+
+#if RV003USB_EVENT_DEBUGGING
+		uint32_t * ue = GetUEvent();
+		if( ue )
+		{
+			printf( "%lu %lx %lx %lx\n", ue[0], ue[1], ue[2], ue[3] );
+		}
+#endif
+		if( start_leds )
+		{
+			ledat = 3;
+			if( scratch[1] == 0xa4 )
+			{
+				WS2812BDMAStart( 254/4 );
+			}
+			start_leds = 0;
+			frame++;
+		}
+	}
+}
+
+void usb_handle_user_in_request( struct usb_endpoint * e, uint8_t * scratchpad, int endp, uint32_t sendtok, struct rv003usb_internal * ist )
+{
+	// Make sure we only deal with control messages.  Like get/set feature reports.
+	if( endp )
+	{
+		usb_send_empty( sendtok );
+	}
+}
+
+void usb_handle_user_data( struct usb_endpoint * e, int current_endpoint, uint8_t * data, int len, struct rv003usb_internal * ist )
+{
+	//LogUEvent( SysTick->CNT, current_endpoint, e->count, 0xaaaaaaaa );
+	int offset = e->count<<3;
+	int torx = e->max_len - offset;
+	if( torx > len ) torx = len;
+	if( torx > 0 )
+	{
+		memcpy( scratch + offset, data, torx );
+		e->count++;
+		if( ( e->count << 3 ) >= e->max_len )
+		{
+			start_leds = e->max_len;
+		}
+	}
+}
+
+void usb_handle_hid_get_report_start( struct usb_endpoint * e, int reqLen, uint32_t lValueLSBIndexMSB )
+{
+	if( reqLen > sizeof( scratch ) ) reqLen = sizeof( scratch );
+
+	// You can check the lValueLSBIndexMSB word to decide what you want to do here
+	// But, whatever you point this at will be returned back to the host PC where
+	// it calls hid_get_feature_report. 
+	//
+	// Please note, that on some systems, for this to work, your return length must
+	// match the length defined in HID_REPORT_COUNT, in your HID report, in usb_config.h
+
+	e->opaque = scratch;
+	e->max_len = reqLen;
+}
+
+void usb_handle_hid_set_report_start( struct usb_endpoint * e, int reqLen, uint32_t lValueLSBIndexMSB )
+{
+	// Here is where you get an alert when the host PC calls hid_send_feature_report.
+	//
+	// You can handle the appropriate message here.  Please note that in this
+	// example, the data is chunked into groups-of-8-bytes.
+	//
+	// Note that you may need to make this match HID_REPORT_COUNT, in your HID
+	// report, in usb_config.h
+
+	if( reqLen > sizeof( scratch ) ) reqLen = sizeof( scratch );
+	e->max_len = reqLen;
+}
+
+
+void usb_handle_other_control_message( struct usb_endpoint * e, struct usb_urb * s, struct rv003usb_internal * ist )
+{
+	LogUEvent( SysTick->CNT, s->wRequestTypeLSBRequestMSB, s->lValueLSBIndexMSB, s->wLength );
+}
+
+

--- a/demo_exti/funconfig.h
+++ b/demo_exti/funconfig.h
@@ -1,0 +1,14 @@
+#ifndef _FUNCONFIG_H
+#define _FUNCONFIG_H
+
+#define FUNCONF_USE_DEBUGPRINTF 1
+#define CH32V003                1
+#define FUNCONF_SYSTICK_USE_HCLK 1
+#define RV003_ADD_EXTI_MASK (1<<7)
+#define RV003_ADD_EXTI_HANDLER \
+				la a5, another_interrupt_flag; \
+				li a0, 1; \
+				sw a0, 0(a5); \
+
+#endif
+

--- a/demo_exti/usb_config.h
+++ b/demo_exti/usb_config.h
@@ -1,0 +1,156 @@
+#ifndef _USB_CONFIG_H
+#define _USB_CONFIG_H
+
+//Defines the number of endpoints for this device. (Always add one for EP0). For two EPs, this should be 3.
+#define ENDPOINTS 2
+
+#define USB_PORT D     // [A,C,D] GPIO Port to use with D+, D- and DPU
+#define USB_PIN_DP 3   // [0-4] GPIO Number for USB D+ Pin
+#define USB_PIN_DM 4   // [0-4] GPIO Number for USB D- Pin
+// #define USB_PIN_DPU 5  // [0-7] GPIO for feeding the 1.5k Pull-Up on USB D- Pin; Comment out if not used / tied to 3V3!
+
+#define RV003USB_DEBUG_TIMING      0
+#define RV003USB_OPTIMIZE_FLASH    1
+#define RV003USB_EVENT_DEBUGGING   0
+#define RV003USB_HANDLE_IN_REQUEST 1
+#define RV003USB_OTHER_CONTROL     1
+#define RV003USB_HANDLE_USER_DATA  1
+#define RV003USB_HID_FEATURES      1
+
+
+#ifndef __ASSEMBLER__
+
+#include <tinyusb_hid.h>
+
+#ifdef INSTANCE_DESCRIPTORS
+
+//Taken from http://www.usbmadesimple.co.uk/ums_ms_desc_dev.htm
+static const uint8_t device_descriptor[] = {
+	18, //Length
+	1,  //Type (Device)
+	0x10, 0x01, //Spec
+	0x0, //Device Class
+	0x0, //Device Subclass
+	0x0, //Device Protocol  (000 = use config descriptor)
+	0x08, //Max packet size for EP0 (This has to be 8 because of the USB Low-Speed Standard)
+	0x09, 0x12, //ID Vendor
+	0x03, 0xd0, //ID Product
+	0x02, 0x00, //ID Rev
+	1, //Manufacturer string
+	2, //Product string
+	3, //Serial string
+	1, //Max number of configurations
+};
+
+static const uint8_t special_hid_desc[] = { 
+	HID_USAGE_PAGE ( 0xff ), // Vendor-defined page.
+	HID_USAGE      ( 0x00 ),
+	HID_REPORT_SIZE ( 8 ),
+	HID_COLLECTION ( HID_COLLECTION_LOGICAL ),
+		HID_REPORT_COUNT   ( 254 ),
+		HID_REPORT_ID      ( 0xaa )
+		HID_USAGE          ( 0x01 ),
+		HID_FEATURE        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,
+		HID_REPORT_COUNT   ( 63 ), // For use with `hidapitester --vidpid 1209/D003 --open --read-feature 171`
+		HID_REPORT_ID      ( 0xab )
+		HID_USAGE          ( 0x01 ),
+		HID_FEATURE        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,
+	HID_COLLECTION_END,
+};
+
+static const uint8_t config_descriptor[] = {
+	// configuration descriptor, USB spec 9.6.3, page 264-266, Table 9-10
+	9, 					// bLength;
+	2,					// bDescriptorType;
+	0x22, 0x00,			// wTotalLength  	
+
+	//34, 0x00, //for just the one descriptor
+	
+	0x01,					// bNumInterfaces (Normally 1)
+	0x01,					// bConfigurationValue
+	0x00,					// iConfiguration
+	0x80,					// bmAttributes (was 0xa0)
+	0x64,					// bMaxPower (200mA)
+
+	//class FF device
+	9,					// bLength
+	4,					// bDescriptorType
+	0,		            // bInterfaceNumber  = 1 instead of 0 -- well make it second.
+	0,					// bAlternateSetting
+	1,					// bNumEndpoints
+	0x03,				// bInterfaceClass (0x03 = HID)
+	0x00,				// bInterfaceSubClass
+	0xff,				// bInterfaceProtocol (1 = Keyboard, 2 = Mouse)
+	0,					// iInterface
+
+	9,					// bLength
+	0x21,					// bDescriptorType (HID)
+	0x10,0x01,	  // bcd 1.1
+	0x00,         //country code
+	0x01,         // Num descriptors
+	0x22,         // DescriptorType[0] (HID)
+	sizeof(special_hid_desc), 0x00, 
+
+	7,            // endpoint descriptor (For endpoint 1)
+	0x05,         // Endpoint Descriptor (Must be 5)
+	0x81,         // Endpoint Address
+	0x03,         // Attributes
+	0x01,	0x00, // Size (We aren't using it)
+	100,          // Interval (We don't use it.)
+};
+
+#define STR_MANUFACTURER u"CNLohr"
+#define STR_PRODUCT      u"RV003 Custom Device"
+#define STR_SERIAL       u"CUSTOMDEVICE000"
+
+struct usb_string_descriptor_struct {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+	uint16_t wString[];
+};
+const static struct usb_string_descriptor_struct string0 __attribute__((section(".rodata"))) = {
+	4,
+	3,
+	{0x0409}
+};
+const static struct usb_string_descriptor_struct string1 __attribute__((section(".rodata")))  = {
+	sizeof(STR_MANUFACTURER),
+	3,
+	STR_MANUFACTURER
+};
+const static struct usb_string_descriptor_struct string2 __attribute__((section(".rodata")))  = {
+	sizeof(STR_PRODUCT),
+	3,
+	STR_PRODUCT
+};
+const static struct usb_string_descriptor_struct string3 __attribute__((section(".rodata")))  = {
+	sizeof(STR_SERIAL),
+	3,
+	STR_SERIAL
+};
+
+// This table defines which descriptor data is sent for each specific
+// request from the host (in wValue and wIndex).
+const static struct descriptor_list_struct {
+	uint32_t	lIndexValue;
+	const uint8_t	*addr;
+	uint8_t		length;
+} descriptor_list[] = {
+	{0x00000100, device_descriptor, sizeof(device_descriptor)},
+	{0x00000200, config_descriptor, sizeof(config_descriptor)},
+	// interface number // 2200 for hid descriptors.
+	{0x00002200, special_hid_desc, sizeof(special_hid_desc)},
+	{0x00002100, config_descriptor + 18, 9 }, // Not sure why, this seems to be useful for Windows + Android.
+
+	{0x00000300, (const uint8_t *)&string0, 4},
+	{0x04090301, (const uint8_t *)&string1, sizeof(STR_MANUFACTURER)},
+	{0x04090302, (const uint8_t *)&string2, sizeof(STR_PRODUCT)},	
+	{0x04090303, (const uint8_t *)&string3, sizeof(STR_SERIAL)}
+};
+#define DESCRIPTOR_LIST_ENTRIES ((sizeof(descriptor_list))/(sizeof(struct descriptor_list_struct)) )
+
+#endif // INSTANCE_DESCRIPTORS
+
+#endif
+
+#endif 

--- a/rv003usb/rv003usb.S
+++ b/rv003usb/rv003usb.S
@@ -29,13 +29,6 @@
 #define SAVE_DEBUG_MARKER(x)	sw	x4, x(sp)
 #endif
 
-#define ANOTHER_INTERRUPT
-#ifdef ANOTHER_INTERRUPT
-#define ANOTHER_INT_PIN 7
-#define ANOTHER_PIN_PORT GPIOC
-.global another_interrupt_flag
-#endif
-
 .global test_memory
 .global rv003usb_internal_data
 .global rv003usb_handle_packet
@@ -52,6 +45,11 @@ Compressed:
 
 .section .text.vector_handler
 .global EXTI7_0_IRQHandler
+/*
+#ifdef RV003_ADD_EXTI_MASK
+.extern another_interrupt_handler
+#endif
+*/
 .balign 4
 EXTI7_0_IRQHandler:
 	addi	sp,sp,-80
@@ -63,17 +61,16 @@ EXTI7_0_IRQHandler:
 
 	sw	a1, 4(sp)
 	sw	a2, 8(sp)
-; /*
-#ifdef ANOTHER_INTERRUPT
-	la a1, 0x40010414 //	R32_EXTI_INTFR
-	c.lw a2, 0(a1)
-	c.andi a2, USB_DMASK
-	c.beqz a2, another_interrupt_symbol
-#endif
-; */
 	sw	a3, 12(sp)
 	sw	a4, 16(sp)
 	sw	s1, 28(sp)
+
+#if defined (RV003_ADD_EXTI_MASK) && defined (RV003_ADD_EXTI_HANDLER)
+	la a1, 0x40010414 //	R32_EXTI_INTFR
+	c.lw a2, 0(a1)
+	c.andi a2, USB_DMASK
+	c.beqz a2, another_interrupt_handler
+#endif
 
 	SAVE_DEBUG_MARKER( 48 );
 	DEBUG_TICK_SETUP
@@ -421,6 +418,17 @@ done_usb_message_in:
 	lw	t2, 40(sp)
 	lw  ra, 52(sp)
 
+#if defined (RV003_ADD_EXTI_MASK) && defined (RV003_ADD_EXTI_HANDLER)
+another_interrupt_check:
+	la a5, EXTI_BASE + 20
+	lw a0, 0(a5)
+	andi a0, a0, RV003_ADD_EXTI_MASK
+	c.beqz a0, ret_from_se0
+
+another_interrupt_handler:
+	RV003_ADD_EXTI_HANDLER
+#endif
+
 ret_from_se0:
 	lw	s1, 28(sp)
 	RESTORE_DEBUG_MARKER(48)
@@ -435,12 +443,11 @@ interrupt_complete:
 	c.j 1f; 1: // Extra little bit of delay to make sure we don't accidentally false fire.
 
 	la a5, EXTI_BASE + 20
-#ifdef ANOTHER_INTERRUPT
-	lw a0, 0(a5)
-	andi a0, a0, 0x00080
-	c.bnez a0, another_interrupt_symbol
-#endif
+#ifdef RV003_ADD_EXTI_MASK
+	li a0, (RV003_ADD_EXTI_MASK|(1<<USB_PIN_DM))
+#else
 	li a0, (1<<USB_PIN_DM)
+#endif
 	sw a0, 0(a5)
 	
 	// Restore stack.
@@ -448,30 +455,6 @@ interrupt_complete:
 	lw	a5, 20(sp)
 	addi	sp,sp,80
 	mret
-
-#ifdef ANOTHER_INTERRUPT
-another_interrupt_symbol:
-	lw	s1, 28(sp)
-	lw	a2, 8(sp)
-/*
-	lui	a5,0x40011
- 	lui	a0,0x10
- 	sw	a0,16(a5)
-*/
-	la a5, another_interrupt_flag
-	li a0, 1
-	sw a0, 0(a5)
-
-	la a5, EXTI_BASE + 20
-	li a0, (1<<ANOTHER_INT_PIN|1<<USB_PIN_DM)
-	sw a0, 0(a5)
-
-	// Restore stack.
-	lw	a0, 0(sp)
-	lw	a5, 20(sp)
-	addi	sp,sp,80
-	mret
-#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 // High level functions.
@@ -930,10 +913,4 @@ always0:
 always0:
 	.word 0x00
 
-#endif
-
-#ifdef ANOTHER_INTERRUPT
-.section .data
-another_interrupt_flag:
-	.word 0x00
 #endif

--- a/rv003usb/rv003usb.S
+++ b/rv003usb/rv003usb.S
@@ -45,11 +45,7 @@ Compressed:
 
 .section .text.vector_handler
 .global EXTI7_0_IRQHandler
-/*
-#ifdef RV003_ADD_EXTI_MASK
-.extern another_interrupt_handler
-#endif
-*/
+
 .balign 4
 EXTI7_0_IRQHandler:
 	addi	sp,sp,-80
@@ -69,7 +65,7 @@ EXTI7_0_IRQHandler:
 	la a1, 0x40010414 //	R32_EXTI_INTFR
 	c.lw a2, 0(a1)
 	c.andi a2, USB_DMASK
-	c.beqz a2, another_interrupt_handler
+	c.beqz a2, another_interrupt_check
 #endif
 
 	SAVE_DEBUG_MARKER( 48 );

--- a/rv003usb/rv003usb.S
+++ b/rv003usb/rv003usb.S
@@ -29,6 +29,12 @@
 #define SAVE_DEBUG_MARKER(x)	sw	x4, x(sp)
 #endif
 
+#define ANOTHER_INTERRUPT
+#ifdef ANOTHER_INTERRUPT
+#define ANOTHER_INT_PIN 7
+#define ANOTHER_PIN_PORT GPIOC
+.global another_interrupt_flag
+#endif
 
 .global test_memory
 .global rv003usb_internal_data
@@ -57,6 +63,14 @@ EXTI7_0_IRQHandler:
 
 	sw	a1, 4(sp)
 	sw	a2, 8(sp)
+; /*
+#ifdef ANOTHER_INTERRUPT
+	la a1, 0x40010414 //	R32_EXTI_INTFR
+	c.lw a2, 0(a1)
+	c.andi a2, USB_DMASK
+	c.beqz a2, another_interrupt_symbol
+#endif
+; */
 	sw	a3, 12(sp)
 	sw	a4, 16(sp)
 	sw	s1, 28(sp)
@@ -421,7 +435,35 @@ interrupt_complete:
 	c.j 1f; 1: // Extra little bit of delay to make sure we don't accidentally false fire.
 
 	la a5, EXTI_BASE + 20
+#ifdef ANOTHER_INTERRUPT
+	lw a0, 0(a5)
+	andi a0, a0, 0x00080
+	c.bnez a0, another_interrupt_symbol
+#endif
 	li a0, (1<<USB_PIN_DM)
+	sw a0, 0(a5)
+	
+	// Restore stack.
+	lw	a0, 0(sp)
+	lw	a5, 20(sp)
+	addi	sp,sp,80
+	mret
+
+#ifdef ANOTHER_INTERRUPT
+another_interrupt_symbol:
+	lw	s1, 28(sp)
+	lw	a2, 8(sp)
+/*
+	lui	a5,0x40011
+ 	lui	a0,0x10
+ 	sw	a0,16(a5)
+*/
+	la a5, another_interrupt_flag
+	li a0, 1
+	sw a0, 0(a5)
+
+	la a5, EXTI_BASE + 20
+	li a0, (1<<ANOTHER_INT_PIN|1<<USB_PIN_DM)
 	sw a0, 0(a5)
 
 	// Restore stack.
@@ -429,6 +471,7 @@ interrupt_complete:
 	lw	a5, 20(sp)
 	addi	sp,sp,80
 	mret
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 // High level functions.
@@ -889,4 +932,8 @@ always0:
 
 #endif
 
-
+#ifdef ANOTHER_INTERRUPT
+.section .data
+another_interrupt_flag:
+	.word 0x00
+#endif


### PR DESCRIPTION
All additions to ``rv003usb.S`` are fenced with ``#ifdef``s, so unless you decide to use more interrupts, USB code stays the same. This addition is useful, because you can avoid editing the source of rv003usb in your project, making it more portable.