### PR TITLE
Fixing enumeration when rebooting into the program from bootloader

### DIFF
--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -83,11 +83,13 @@ static inline void asmDelay(int delay) {
 "bne %[delay], x0, 1b\n" :[delay]"+r"(delay)  );
 }
 
-#ifndef USB_PORT_DPU
+#ifndef USB_PIN_DPU
 extern uint32_t _boot_firmware_xor;
 uint32_t secret_xor __attribute__((section(".secret_address"))) __attribute__((used)) = (uint32_t)(&_boot_firmware_xor);
 // noreturn attribute saves 2-4 bytes. We can use it because we reboot the chip at the end of this function
 void boot_usercode() __attribute__((section(".boot_firmware"))) __attribute__((noinline, noreturn));
+#else
+uint32_t secret_xor __attribute__((section(".secret_address"))) __attribute__((used)) = 0;
 #endif
 
 void boot_usercode()
@@ -96,7 +98,7 @@ void boot_usercode()
 	GPIOC->CFGLR = (GPIO_Speed_10MHz | GPIO_CNF_OUT_PP)<<(4*0);
 	GPIOC->BSHR = 1<<(0);
 #endif
-#ifndef USB_PORT_DPU
+#ifndef USB_PIN_DPU
 	LOCAL_EXP(GPIO,USB_PORT)->CFGLR = (GPIO_Speed_10MHz | GPIO_CNF_OUT_PP)<<(4*USB_PIN_DM);
 	LOCAL_EXP(GPIO,USB_PORT)->BSHR = 1<<(USB_PIN_DM + 16);
 	asmDelay(1000000);

--- a/bootloader/ch32v003fun-usb-bootloader.ld
+++ b/bootloader/ch32v003fun-usb-bootloader.ld
@@ -3,7 +3,8 @@ ENTRY( InterruptVector )
 MEMORY
 {
 	/* Actually at 0x1FFFF000 but the system maps it to 0x00000000 */
-	FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 1920
+	FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 1916
+	SECRET (rx) : ORIGIN = 0x0000077C, LENGTH = 4
 	RAM (xrw)	: ORIGIN = 0x20000000, LENGTH = 2K
 }
 
@@ -17,6 +18,14 @@ SECTIONS
 		. = ALIGN(4);
 		_einit = .;
 	} >FLASH AT>FLASH
+
+	.boot_firmware :
+	{
+		. = ALIGN(4);
+		_boot_firmware_xor = ABSOLUTE(((ABSOLUTE(.)^0x77C)<<16)|ABSOLUTE(.));
+		KEEP(*(.boot_firmware))
+		. = ALIGN(4);
+	}	>FLASH AT>FLASH
 
 	.text :
 	{
@@ -103,6 +112,12 @@ SECTIONS
 		. = ALIGN(4); 
 		PROVIDE(_data_lma = .);
 	} >FLASH AT>FLASH
+
+	.secret_address :
+	{
+		. = ALIGN(4);
+		KEEP(*(.secret_address))
+	} >SECRET
 
 	.data :
 	{

--- a/rv003usb/rv003usb.c
+++ b/rv003usb/rv003usb.c
@@ -150,6 +150,7 @@ void usb_pid_handle_in( uint32_t addr, uint8_t * data, uint32_t endp, uint32_t u
 		FLASH->BOOT_MODEKEYR = FLASH_KEY2;
 		FLASH->STATR = 1<<14; // 1<<14 is zero, so, boot bootloader code. Unset for user code.
 		FLASH->CTLR = CR_LOCK_Set;
+		RCC->RSTSCKR |= 0x1000000;
 		PFIC->SCTLR = 1<<31;
 	}
 #endif

--- a/rvswdio_programmer/README.md
+++ b/rvswdio_programmer/README.md
@@ -8,9 +8,8 @@ This is still a bit of an RFC and should not be considered the "real path" movin
 
 Simply use a CH32V003, connected as follows:
 
-![Schematic](https://github.com/cnlohr/rv003usb/blob/swio_programmer/testing/rvswdio_programmer/schematic.png?raw=true)
+![Schematic](schematic.png)
 
 And you can program, semihost and run basic GDB on a variety of WCH chips including the CH32V003, 20x, 30x and x03x.
 
 It's actually only a little slower than the normal programmer somehow, in spite of bit banging USB?
-


### PR DESCRIPTION
Boards that doesn't have a dedicated DPU pin, can't properly re-enumerate from ``b003`` to ``d003`` after rebooting from bootloader. To fix this we need to pull down D- pin for a short period of time. To make this hassle free to the end user, I implemented it in the bootloader code plus corresponding changes to minichlink. This requires extra space, but it fits.
If you are still using dedicated DPU pin, only changes will be the extra 4 bytes used by the updated linker script.

Also fixed added one missing line to the soft reboot into bootloader function. Without it bootloader was booting straight into user code.

The last commit ensures that resulted bin will always be ``1920`` bytes, so we always rewrite whole boot partition and no junk could be left in the end of it from previous bootloader. This is somewhat important, because with updated minichlink we are looking into last 4 bytes of the partition. And in some edge cases we could see unwanted behavior.