### PR TITLE
Fixes to bootloader

### DIFF
--- a/bootloader/ch32v003fun-usb-bootloader.ld
+++ b/bootloader/ch32v003fun-usb-bootloader.ld
@@ -22,7 +22,7 @@ SECTIONS
 	.boot_firmware :
 	{
 		. = ALIGN(4);
-		_boot_firmware_xor = ABSOLUTE(((ABSOLUTE(.)^0x77C)<<16)|ABSOLUTE(.));
+		_boot_firmware_xor = ABSOLUTE((((ABSOLUTE(.)|0x77C) - (ABSOLUTE(.)&0x77C))<<16)|ABSOLUTE(.));
 		KEEP(*(.boot_firmware))
 		. = ALIGN(4);
 	}	>FLASH AT>FLASH

--- a/bootloader/usb_config.h
+++ b/bootloader/usb_config.h
@@ -83,7 +83,7 @@ static const uint8_t config_descriptor[] = {  //Mostly stolen from a USB mouse I
 	0,					// bAlternateSetting
 	1,					// bNumEndpoints
 	0x03,					// bInterfaceClass (0x03 = HID)
-	0xff,					// bInterfaceSubClass
+	0x00,					// bInterfaceSubClass
 	0xff,					// bInterfaceProtocol
 	0,					// iInterface
 


### PR DESCRIPTION
- XOR is not usable by LD on some systems (macos) for some reason
- macos couldn't enumerate USB bootloader with subclass ``0xFF``