### PR TITLE
Quality of Life improvements

### DIFF
--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -61,6 +61,10 @@
 // ----------------------------------
 // #define SOFT_REBOOT_TO_BOOTLOADER
 
+#if defined(BOOTLOADER_BTN_PORT) && (0 != BOOTLOADER_TIMEOUT_PWR)
+#warning "BOOTLOADER_BTN_PORT is defined, but BOOTLOADER_TIMEOUT_PWR is not set to 0. Code might not fit"
+#endif
+
 #define SCRATCHPAD_SIZE 128
 extern volatile int32_t runwordpad;
 static uint32_t runwordpadready = 0;

--- a/rvswdio_programmer/rvswdio_programmer.c
+++ b/rvswdio_programmer/rvswdio_programmer.c
@@ -30,6 +30,9 @@
 
 #define PIN_SWCLK   PC5     // Remappable.
 #define PIN_TARGETPOWER PD2 // Remappable
+#define POWER_ON 1
+#define POWER_OFF 0
+#define PIN_TARGETPOWER_MODE GPIO_CFGLR_OUT_10Mhz_PP
 
 #include "bitbang_rvswdio_ch32v003.h"
 
@@ -93,8 +96,8 @@ static void HandleCommandBuffer( uint8_t * buffer )
 				{
 					//DoSongAndDanceToEnterPgmMode( &state ); was 1.  But really we just want to init.
 					// if we expect this, we can use 0x0e to get status.
-					funPinMode( PIN_TARGETPOWER, GPIO_CFGLR_OUT_10Mhz_PP );
-					funDigitalWrite( PIN_TARGETPOWER, 1 );
+					funPinMode( PIN_TARGETPOWER, PIN_TARGETPOWER_MODE );
+					funDigitalWrite( PIN_TARGETPOWER, POWER_ON );
 					int r = InitializeSWDSWIO( &state );
 					if( cmd == 0x0e )
 						*(retbuffptr++) = r;
@@ -102,11 +105,11 @@ static void HandleCommandBuffer( uint8_t * buffer )
 				}
 				case 0x02: // Power-down 
 					printf( "Power down\n" );
-					funDigitalWrite( PIN_TARGETPOWER, 0 );
+					funDigitalWrite( PIN_TARGETPOWER, POWER_OFF );
 					break;
 				case 0x03: // Power-up
-					funPinMode( PIN_TARGETPOWER, GPIO_CFGLR_OUT_10Mhz_PP );
-					funDigitalWrite( PIN_TARGETPOWER, 1 );
+					funPinMode( PIN_TARGETPOWER, PIN_TARGETPOWER_MODE );
+					funDigitalWrite( PIN_TARGETPOWER, POWER_ON );
 					break;
 				case 0x04: // Delay( uint16_t us )
 					Delay_Us(iptr[0] | (iptr[1]<<8) );


### PR DESCRIPTION
Added a warning to bootloader.c that triggers if both the button and timeout are enabled as the firmware won't build with a confusing linker error.
Also added some macros to rvswdio to allow the use of open drain or inverted logic for the power pin.