### PR TITLE
Improve the programmer. Add CH5xx support

### DIFF
--- a/rvswdio_programmer/README.md
+++ b/rvswdio_programmer/README.md
@@ -1,4 +1,4 @@
-# ch32v003 programmer for WCH V- and X- chips
+# ch32v003 programmer for WCH RiscV chips
 
 While this is in `master`, it should still be considered somewhat experimental.  It may make sense to instead of use two pins, use two timers on a single pin.
 
@@ -10,6 +10,8 @@ Simply use a CH32V003, connected as follows:
 
 ![Schematic](schematic.png)
 
-And you can program, semihost and run basic GDB on a variety of WCH chips including the CH32V003, 20x, 30x and x03x.
+And you can program, semihost and run basic GDB on a variety of WCH chips including the CH32V003, 00x, 20x, 30x, x03x, CH57x, CH585, CH59x.
+
+Tested and not supported: CH32V103, CH582/3. Other CH5xx riscv chips may work, but weren't tested.
 
 It's actually only a little slower than the normal programmer somehow, in spite of bit banging USB?

--- a/rvswdio_programmer/bitbang_rvswdio.h
+++ b/rvswdio_programmer/bitbang_rvswdio.h
@@ -12,7 +12,7 @@
 // Mostly tested, though, not may not be perfect. Expect to tweak some things.
 // The 003 code is pretty hardened, the other code may not be.
 //
-// The only resources used to produce this file were publicly available docs
+// Originally the only resources used to produce this file were publicly available docs
 // and playing with the chips.  The only leveraged tool was this:
 //   https://github.com/perigoso/sigrok-rvswd
 
@@ -843,7 +843,7 @@ chip_identified:
 			reply[0] = sevenf_id;
 			reply[5] = chip_id >> 8;
 			reply[4] = chip_id;
-			if( read_protection == 1 ) reply[5] |= 0x8000;
+			if( read_protection == 1 ) reply[5] |= 0x80;
 		}
 		
 		// Cleanup

--- a/rvswdio_programmer/bitbang_rvswdio.h
+++ b/rvswdio_programmer/bitbang_rvswdio.h
@@ -39,13 +39,29 @@ enum RiscVChip {
 	CHIP_CH32V30x = 0x06,
 	CHIP_CH58x = 0x07,
 	CHIP_CH32V003 = 0x09,
+	CHIP_CH59x = 0x0b,
+	CHIP_CH643 = 0x0c,
 	CHIP_CH32X03x = 0x0d,
+	CHIP_CH32L10x = 0x0e,
+	CHIP_CH564 = 0x0f,
 
+	CHIP_CH32V00x = 0x4e,
 
-	CHIP_CH32V002 = 0x22,
-	CHIP_CH32V004 = 0x24,
-	CHIP_CH32V005 = 0x25,
-	CHIP_CH32V006 = 0x26,
+	CHIP_CH570 = 0x8b,
+	CHIP_CH585 = 0x4b,
+	CHIP_CH645 = 0x46,
+	CHIP_CH641 = 0x49,
+	CHIP_CH32V317 = 0x86,
+	CHIP_CH32M030 = 0x8e,
+};
+
+enum MemoryArea {
+	DEFAULT_AREA = 0,
+	PROGRAM_AREA = 1,
+	BOOTLOADER_AREA = 2,
+	OPTIONS_AREA = 3,
+	EEPROM_AREA = 4,
+	RAM_AREA = 5,
 };
 
 struct SWIOState
@@ -64,6 +80,12 @@ struct SWIOState
 	uint32_t currentstateval;
 	uint32_t flash_unlocked;
 	uint32_t autoincrement;
+	uint32_t clock_set;
+	uint32_t no_autoexec;
+#if CH5xx_SUPPORT
+	int microblob_running;
+	int writing_flash;
+#endif
 };
 
 #define STTAG( x ) (*((uint32_t*)(x)))
@@ -88,15 +110,24 @@ static int MCFReadReg32( struct SWIOState * state, uint8_t command, uint32_t * v
 
 // More advanced functions built on lower level PHY.
 static int InitializeSWDSWIO( struct SWIOState * state );
+#if CH5xx_SUPPORT
+static int ReadByte( struct SWIOState * iss, uint32_t address_to_read, uint8_t * data );
+static int WriteByte( struct SWIOState * iss, uint32_t address_to_write, uint8_t data );
+#endif
 static int ReadWord( struct SWIOState * state, uint32_t word, uint32_t * ret );
 static int WriteWord( struct SWIOState * state, uint32_t word, uint32_t val );
 static int WaitForFlash( struct SWIOState * state );
 static int WaitForDoneOp( struct SWIOState * state );
-static int Write64Block( struct SWIOState * iss, uint32_t address_to_write, uint8_t * data );
+static int WriteBlock( struct SWIOState * iss, uint32_t address_to_write, uint8_t * data, uint8_t len, uint8_t erase );
 static int UnlockFlash( struct SWIOState * iss );
 static int EraseFlash( struct SWIOState * iss, uint32_t address, uint32_t length, int type );
 static void ResetInternalProgrammingState( struct SWIOState * iss );
 static int PollTerminal( struct SWIOState * iss, uint8_t * buffer, int maxlen, uint32_t leavevalA, uint32_t leavevalB );
+
+#if CH5xx_SUPPORT
+extern int ch5xx_set_clock(struct SWIOState * iss, uint32_t clock);
+extern int ch5xx_write_flash_using_microblob(struct SWIOState * iss, uint32_t start_addr, uint8_t* data, uint32_t len);
+#endif
 
 #define BDMDATA0        0x04
 #define BDMDATA1        0x05
@@ -136,8 +167,8 @@ static int PollTerminal( struct SWIOState * iss, uint8_t * buffer, int maxlen, u
 static inline void PrecDelay( int delay )
 {
 	asm volatile( 
-"1:	addi %[delay], %[delay], -1\n"
-"	bbci %[delay], 31, 1b\n" : [delay]"+r"(delay)  );
+"1: addi %[delay], %[delay], -1\n"
+"   bbci %[delay], 31, 1b\n" : [delay]"+r"(delay)  );
 }
 
 // TODO: Add continuation (bypass) functions.
@@ -258,9 +289,9 @@ static void MCFWriteReg32( struct SWIOState * state, uint8_t command, uint32_t v
 	int t1coeff = state->t1coeff;
 	int pinmaskD = state->pinmaskD;
 	int pinmaskC = state->pinmaskC;
- 	GPIO.out_w1ts = pinmaskC;
+	GPIO.out_w1ts = pinmaskC;
 	GPIO.enable_w1ts = pinmaskC;
- 	GPIO.out_w1ts = pinmaskD;
+	GPIO.out_w1ts = pinmaskD;
 	GPIO.enable_w1ts = pinmaskD;
 	//BB_PRINTF_DEBUG( "CO: (%08x=>%08x) %08x %08x %d %d\n", command, value, pinmaskD, pinmaskC, t1coeff, state->opmode );
 	if( state->opmode == 1 )
@@ -528,106 +559,301 @@ static int InitializeSWDSWIO( struct SWIOState * state )
 	return -55;
 }
 
-static int DetermineChipTypeAndSectorInfo( struct SWIOState * iss )
+static int DetermineChipTypeAndSectorInfo( struct SWIOState * iss, uint8_t * reply)
 {
-	if( iss->target_chip_type == CHIP_UNKNOWN )
+	struct SWIOState * dev = iss;
+	if( iss->target_chip_type == CHIP_UNKNOWN || reply != NULL )
 	{
 		if( iss->opmode == 0 )
 		{
 			int r = InitializeSWDSWIO( iss );
-			if( r ) return r;
+			if( r ) return 0x11;
 		}
 		uint32_t rr;
-		if( MCFReadReg32( iss, DMHARTINFO, &rr ) )
+		if( MCFReadReg32( dev, DMHARTINFO, &rr ) )
 		{
 			BB_PRINTF_DEBUG( "Error: Could not get hart info.\n" );
-			return -1;
+			return 0x12;
 		}
 
-		uint32_t data0offset = 0xe0000000 | ( rr & 0x7ff );
-
-		MCFWriteReg32( iss, DMCONTROL, 0x80000001 ); // Make the debug module work properly.
-		MCFWriteReg32( iss, DMCONTROL, 0x80000001 ); // Make the debug module work properly.
+		MCFWriteReg32( dev, DMCONTROL, 0x80000001 ); // Make the debug module work properly.
+		MCFWriteReg32( dev, DMCONTROL, 0x80000001 ); // Initiate halt request.
 
 		// Tricky, this function needs to clean everything up because it may be used entering debugger.
 		uint32_t old_data0;
-		MCFReadReg32( iss, BDMDATA0, &old_data0 );
-		MCFWriteReg32( iss, DMCOMMAND, 0x00221008 );		// Copy data from x8.
+		MCFReadReg32( dev, BDMDATA0, &old_data0 );
+		MCFWriteReg32( dev, DMCOMMAND, 0x00221008 );		// Copy data from x8.
 		uint32_t old_x8;
-		MCFReadReg32( iss, BDMDATA0, &old_x8 );
+		MCFReadReg32( dev, BDMDATA0, &old_x8 );
 
-		uint32_t vendorid = 0;
 		uint32_t marchid = 0;
 
-		MCFWriteReg32( iss, DMABSTRACTCS, 0x08000700 ); // Clear out any dmabstractcs errors.
+		MCFWriteReg32( dev, DMABSTRACTCS, 0x08000700 ); // Clear out any dmabstractcs errors.
 
-		MCFWriteReg32( iss, DMABSTRACTAUTO, 0x00000000 );
-		MCFWriteReg32( iss, DMCOMMAND, 0x00220000 | 0xf12 );
-		MCFWriteReg32( iss, DMCOMMAND, 0x00220000 | 0xf12 );  // Need to double-read, not sure why.
-		MCFReadReg32( iss, BDMDATA0, &marchid );
+		MCFWriteReg32( dev, DMABSTRACTAUTO, 0x00000000 );
+		MCFWriteReg32( dev, DMCOMMAND, 0x00220000 | 0xf12 );
+		MCFWriteReg32( dev, DMCOMMAND, 0x00220000 | 0xf12 );  // Need to double-read, not sure why.
+		MCFReadReg32( dev, BDMDATA0, &marchid );
+		MCFWriteReg32( dev, DMPROGBUF0, 0x90024000 );		// c.ebreak <<== c.lw x8, 0(x8)
 
-		MCFWriteReg32( iss, DMPROGBUF0, 0x90024000 );		// c.ebreak <<== c.lw x8, 0(x8)
-		MCFWriteReg32( iss, BDMDATA0, 0x1ffff704 );			// Special chip ID location.
-		MCFWriteReg32( iss, DMCOMMAND, 0x00271008 );		// Copy data to x8, and execute.
+		uint32_t chip_id = 0;
+		uint32_t vendor_bytes = 0;
+		uint32_t sevenf_id = 0;
+		int read_protection = 0;
+		uint8_t ch5xx = 0;
+		MCFReadReg32( dev, 0x7f, &sevenf_id );
 
-		uint32_t abstractcscheck = 0;
-		MCFReadReg32( iss, DMABSTRACTCS, &abstractcscheck );
-
-		WaitForDoneOp( iss ); //Doesn't need to actually do this, but we can wait here.
-
-		MCFWriteReg32( iss, DMCOMMAND, 0x00221008 );		// Copy data from x8.
-		MCFReadReg32( iss, BDMDATA0, &vendorid );
-
-		// Cleanup
-		MCFWriteReg32( iss, BDMDATA0, old_x8 );
-		MCFWriteReg32( iss, DMCOMMAND, 0x00231008 );		// Copy data to x8
-		MCFWriteReg32( iss, BDMDATA0, old_data0 );
-
-		if( data0offset == 0xe00000f4 )
+		if( sevenf_id == 0 )
 		{
-			// Only known processor with this signature = 0 is a CH32V003.
-			switch( vendorid >> 20 )
+			// Need to load new progbuf because we're reading 1 byte now
+			MCFWriteReg32( dev, DMPROGBUF0, 0x00040403 ); // lb x8, 0(x8)
+			MCFWriteReg32( dev, DMPROGBUF1, 0x00100073 ); // c.ebreak
+			MCFWriteReg32( dev, BDMDATA0, 0x40001041 );			// Special chip ID location.
+			MCFWriteReg32( dev, DMCOMMAND, 0x00271008 );		// Copy data to x8, and execute.
+			WaitForDoneOp( dev );
+			MCFWriteReg32( dev, DMCOMMAND, 0x00221008 );		// Copy data from x8.
+			MCFReadReg32( dev, BDMDATA0, &chip_id );
+			chip_id = chip_id & 0xff;
+
+			// Looks like a CH32V103 or a CH56x
+			if( chip_id == 0 )
 			{
-			case 0x002: iss->target_chip_type = CHIP_CH32V002; iss->sectorsize = 256; break;
-			case 0x004: iss->target_chip_type = CHIP_CH32V004; iss->sectorsize = 256; break;
-			case 0x005: iss->target_chip_type = CHIP_CH32V005; iss->sectorsize = 256; break;
-			case 0x006: iss->target_chip_type = CHIP_CH32V006; iss->sectorsize = 256; break;
-			default:    iss->target_chip_type = CHIP_CH32V003; iss->sectorsize = 64; break; // not usually 003
-			}
-			// Examples:
-			// 00000012 = CHIP_CH32V003
-		}
-		else if( data0offset == 0xe0000380 )
-		{
-			// All other known chips.
-			uint32_t chip_type = (vendorid & 0xff000000)>>24;
-			switch( chip_type )
-			{
-				case 0x10:
+				// First check for CH56x
+				MCFWriteReg32( dev, BDMDATA0, 0x40001001 );			
+				MCFWriteReg32( dev, DMCOMMAND, 0x00271008 );		// Copy data to x8, and execute.
+				WaitForDoneOp( dev );
+				MCFWriteReg32( dev, DMCOMMAND, 0x00221008 );		// Copy data from x8.
+				MCFReadReg32( dev, BDMDATA0, &chip_id );
+				MCFWriteReg32( dev, BDMDATA0, 0x40001002 );			// Special chip ID location.
+				MCFWriteReg32( dev, DMCOMMAND, 0x00271008 );		// Copy data to x8, and execute.
+				WaitForDoneOp( dev );
+				MCFWriteReg32( dev, DMCOMMAND, 0x00221008 );		// Copy data from x8.
+				MCFReadReg32( dev, BDMDATA0, &vendor_bytes );
+
+				if( (vendor_bytes & 0xff) == 2 && ((chip_id & 0xff) == 65 || (chip_id & 0xff) == 69) )
+				{
+					iss->target_chip_type = CHIP_CH56x;
+					chip_id = 0x500 | (chip_id & 0xff);
+					goto chip_identified;
+				}
+
+				// Now actually check for CH32V103
+				MCFWriteReg32( dev, DMPROGBUF0, 0x90024000 );	// c.ebreak <<== c.lw x8, 0(x8)
+				MCFWriteReg32( dev, BDMDATA0, 0x1ffff880 );			// Special chip ID location.
+				MCFWriteReg32( dev, DMCOMMAND, 0x00271008 );		// Copy data to x8, and execute.
+				WaitForDoneOp( dev );
+				MCFWriteReg32( dev, DMCOMMAND, 0x00221008 );		// Copy data from x8.
+				MCFReadReg32( dev, BDMDATA0, &chip_id );
+				MCFWriteReg32( dev, BDMDATA0, 0x1ffff884 );			// Special chip ID location.
+				MCFWriteReg32( dev, DMCOMMAND, 0x00271008 );		// Copy data to x8, and execute.
+				WaitForDoneOp( dev );
+				MCFWriteReg32( dev, DMCOMMAND, 0x00221008 );		// Copy data from x8.
+				MCFReadReg32( dev, BDMDATA0, &vendor_bytes );
+				
+				if( ((((vendor_bytes >> 16) & 0xff00) != 0x2500) && (((vendor_bytes >> 16) & 0xdf00) != 0x1500)) || chip_id != 0xdc78fe34 )
+				{
+					uint32_t flash_obr = 0;
+					MCFWriteReg32( dev, BDMDATA0, 0x4002201c );			// Special chip ID location.
+					MCFWriteReg32( dev, DMCOMMAND, 0x00271008 );		// Copy data to x8, and execute.
+					WaitForDoneOp( dev );
+					MCFWriteReg32( dev, DMCOMMAND, 0x00221008 );		// Copy data from x8.
+					MCFReadReg32( dev, BDMDATA0, &flash_obr );
+						
+					if( (flash_obr & 3) == 2 )
+					{
+						iss->target_chip_type = CHIP_CH32V10x;
+						iss->no_autoexec = 1;
+						iss->sectorsize = 128;
+						read_protection = 1;
+						chip_id = (3 << 12) | 0x103;
+					}
+				}
+				else
+				{
 					iss->target_chip_type = CHIP_CH32V10x;
-					iss->sectorsize = 256; // test me!
-					break;
-				case 0x03: // x03x
-					iss->target_chip_type = CHIP_CH32X03x;
-					iss->sectorsize = 256;  // Should be 128, but, doesn't work with 128, only 256
-					break;
-				case 0x20: // v20x
+					iss->no_autoexec = 1;
+					iss->sectorsize = 128;
+					read_protection = -1;
+					chip_id = (3 << 12) | 0x103;
+				}
+			}
+			else
+			{
+				// Check for CH5xx        
+				read_protection = -1;
+				if( (chip_id & 0xf0) == 0x90 )
+				{
+					uint32_t sevenc = 0;
+					MCFReadReg32( dev, DMCPBR, &sevenc );
+					if((sevenc & 0x30000) == 0)
+					{
+						iss->target_chip_type = CHIP_CH59x;
+						iss->sectorsize = 256;
+						ch5xx = 1;
+						chip_id = 0x500 | chip_id;
+					}
+					else
+					{
+						iss->target_chip_type = CHIP_CH585;
+						iss->no_autoexec = 1;
+						iss->sectorsize = 256;
+						ch5xx = 1;
+						chip_id = 0x500 | 0x85;
+					}
+				}
+				else
+				{
+					if( chip_id == 0x70 || chip_id == 0x72 )
+					{
+						iss->target_chip_type = CHIP_CH570;
+						iss->sectorsize = 4096;
+						ch5xx = 1;
+						chip_id = 0x500 | chip_id;
+					}
+					else if( chip_id == 0x71 || chip_id == 0x73 )
+					{
+						iss->target_chip_type = CHIP_CH57x;
+						iss->no_autoexec = 1;
+						iss->sectorsize = 256;
+						ch5xx = 1;
+						chip_id = 0x500 | chip_id;
+					}
+					else if( chip_id == 0x82 || chip_id == 0x83 )
+					{
+						iss->target_chip_type = CHIP_CH58x;
+						iss->no_autoexec = 1;
+						iss->sectorsize = 256;
+						ch5xx = 1;
+						chip_id = 0x500 | chip_id;
+					}
+				}
+			}
+		}
+		else
+		{
+			uint32_t masked_id = sevenf_id & 0xfff00000;
+			uint32_t masked_id2 = sevenf_id & 0xfff00f00;
+			if( masked_id == 0x3b00000 )
+			{
+				iss->target_chip_type = CHIP_CH32M030;
+				iss->sectorsize = 256;
+				chip_id = (2 << 12) | 0x30;
+			}
+			else if( masked_id == 0x56400000 )
+			{
+				iss->target_chip_type = CHIP_CH564;
+				iss->sectorsize = 256;
+				chip_id = 0x564;
+			}
+			else if( masked_id == 0x31700000 )
+			{
+				iss->target_chip_type = CHIP_CH32V317;
+				iss->sectorsize = 256;
+				chip_id = (3 << 12) | 0x317;
+			}
+			else if( masked_id == 0x00200000 || masked_id == 0x00400000 || masked_id == 0x00600000 || masked_id == 0x00700000 )
+			{
+				iss->target_chip_type = CHIP_CH32V00x;
+				iss->sectorsize = 256;
+				chip_id = (3 << 12) | (masked_id >> 20);
+			}
+
+			if( masked_id2 == 0x64100500 )
+			{
+				iss->target_chip_type = CHIP_CH641;
+				iss->sectorsize = 64;
+				chip_id = 0x641;
+			}
+			else if( masked_id2 == 0x64300600 )
+			{
+				iss->target_chip_type = CHIP_CH643;
+				iss->sectorsize = 256;
+				chip_id = 0x643;
+			}
+			else if( masked_id == 0x64500000 )
+			{
+				iss->target_chip_type = CHIP_CH645;
+				iss->sectorsize = 256;
+				chip_id = 0x645;
+			}
+			else if( masked_id2 == 0x3500600 )
+			{
+				iss->target_chip_type = CHIP_CH32X03x;
+				iss->sectorsize = 256;
+				chip_id = (4 << 12) | 0x35;
+			}
+			else if( masked_id2 == 0x10300700 )
+			{
+				iss->target_chip_type = CHIP_CH32L10x;
+				iss->sectorsize = 256;
+				chip_id = (1 << 12) | 0x103;
+			}
+			else if( masked_id2 == 0x300500 )
+			{
+				iss->target_chip_type = CHIP_CH32V003;
+				iss->sectorsize = 64;
+				chip_id = (3 << 12) | 0x3;
+			}
+
+			if( (sevenf_id & 0x20000500) == 0x20000500 || (sevenf_id & 0x30000500) == 0x30000500 )
+			{
+				switch ((sevenf_id & 0xfff00000) >> 20)
+				{
+				case 0x203:
+				case 0x208:
 					iss->target_chip_type = CHIP_CH32V20x;
 					iss->sectorsize = 256;
 					break;
-				case 0x30:
+				case 0x303:
+				case 0x305:
+				case 0x307:
 					iss->target_chip_type = CHIP_CH32V30x;
 					iss->sectorsize = 256;
 					break;
+				}
+				chip_id = (3 << 12) | (masked_id >> 20);
 			}
 		}
-		//BB_PRINTF_DEBUG( "Detected %d / %d\n", iss->target_chip_type, iss->sectorsize );
-		//BB_PRINTF_DEBUG( "Vendored: %08x\n", (unsigned)vendorid );
-		//BB_PRINTF_DEBUG( "marchid : %08x\n", (unsigned)marchid );
-		//BB_PRINTF_DEBUG( "HARTINFO: %08x\n", (unsigned)rr );
 
+chip_identified:
+
+		if( read_protection == 0 )
+		{
+			uint32_t one;
+			int two;
+			MCFWriteReg32( dev, BDMDATA0, 0x4002201c );			
+			MCFWriteReg32( dev, DMCOMMAND, 0x00271008 );		// Copy data to x8, and execute.
+			WaitForDoneOp( dev );
+			MCFWriteReg32( dev, DMCOMMAND, 0x00221008 );		// Copy data from x8.
+			MCFReadReg32( dev, BDMDATA0, &one );
+			MCFWriteReg32( dev, BDMDATA0, 0x40022020 );			
+			MCFWriteReg32( dev, DMCOMMAND, 0x00271008 );		// Copy data to x8, and execute.
+			WaitForDoneOp( dev );
+			MCFWriteReg32( dev, DMCOMMAND, 0x00221008 );		// Copy data from x8.
+			MCFReadReg32( dev, BDMDATA0, (uint32_t*)&two );
+			
+			if( (one & 2) || two != -1 ) read_protection = 1;
+		}
+
+		if( reply != NULL )
+		{
+			reply[3] = sevenf_id >> 24;
+			reply[2] = sevenf_id >> 16;
+			reply[1] = sevenf_id >> 8;
+			reply[0] = sevenf_id;
+			reply[5] = chip_id >> 8;
+			reply[4] = chip_id;
+			if( read_protection == 1 ) reply[5] |= 0x8000;
+		}
+		
+		// Cleanup
+		MCFWriteReg32( dev, BDMDATA0, old_x8 );
+		MCFWriteReg32( dev, DMCOMMAND, 0x00231008 );		// Copy data to x8
+		MCFWriteReg32( dev, BDMDATA0, old_data0 );
 		iss->statetag = STTAG( "XXXX" );
-		if( !iss->target_chip_type ) return -5;
+#if CH5xx_SUPPORT
+		if( ch5xx ) ch5xx_set_clock( dev, 0 );
+#endif
 	}
 	return 0;
 }
@@ -636,7 +862,7 @@ static int WaitForFlash( struct SWIOState * iss )
 {
 	struct SWIOState * dev = iss;
 
-	if( DetermineChipTypeAndSectorInfo( iss ) ) return -9;
+	if( DetermineChipTypeAndSectorInfo( iss, NULL ) ) return -9;
 
 	uint32_t rw, timeout = 0;
 	do
@@ -681,7 +907,7 @@ static int WaitForDoneOp( struct SWIOState * iss )
 
 static int StaticUpdatePROGBUFRegs( struct SWIOState * dev )
 {
-	if( DetermineChipTypeAndSectorInfo( dev ) ) return -9;
+	if( DetermineChipTypeAndSectorInfo( dev, NULL ) ) return -9;
 
 	MCFWriteReg32( dev, DMABSTRACTAUTO, 0 ); // Disable Autoexec.
 	uint32_t rr;
@@ -711,6 +937,38 @@ static void ResetInternalProgrammingState( struct SWIOState * iss )
 	iss->currentstateval = 0;
 	iss->flash_unlocked = 0;
 	iss->autoincrement = 0;
+	iss->clock_set = 0;
+#if CH5xx_SUPPORT
+	iss->microblob_running = -2;
+	iss->writing_flash = 0;
+#endif
+}
+
+static int ReadByte( struct SWIOState * iss, uint32_t address_to_read, uint8_t * data )
+{
+	struct SWIOState * dev = iss;
+	int ret = 0;
+	iss->statetag = STTAG( "XXXX" );
+
+	MCFWriteReg32( dev, DMABSTRACTAUTO, 0x00000000 ); // Disable Autoexec.
+
+	// Different address, so we don't need to re-write all the program regs.
+	// lb x8,0(x9)  // Read from the address.
+	MCFWriteReg32( dev, DMPROGBUF0, 0x00048403 ); // lb x8, 0(x9)
+	MCFWriteReg32( dev, DMPROGBUF1, 0x00100073 ); // c.ebreak
+
+	MCFWriteReg32( dev, BDMDATA0, address_to_read );
+	MCFWriteReg32( dev, DMCOMMAND, 0x00231009 ); // Copy data to x9
+	MCFWriteReg32( dev, DMCOMMAND, 0x00241000 ); // Only execute.
+	MCFWriteReg32( dev, DMCOMMAND, 0x00221008 ); // Read x8 into DATA0.
+
+	ret |= WaitForDoneOp( dev );
+	iss->currentstateval = -1;
+
+	uint32_t rr;
+	ret |= MCFReadReg32( dev, BDMDATA0, &rr );
+	*data = rr;
+	return ret;
 }
 
 static int ReadWord( struct SWIOState * iss, uint32_t address_to_read, uint32_t * data )
@@ -753,12 +1011,14 @@ static int ReadWord( struct SWIOState * iss, uint32_t address_to_read, uint32_t 
 			// c.sw x8, 0(x11) // Write addy to DATA1
 			// c.ebreak
 			MCFWriteReg32( dev, DMPROGBUF2, 0x9002c180 );
-			MCFWriteReg32( dev, DMABSTRACTAUTO, 1 ); // Enable Autoexec (not autoincrement)
+			if( !iss->no_autoexec )
+				MCFWriteReg32( dev, DMABSTRACTAUTO, 1 ); // Enable Autoexec (not autoincrement)
 			iss->autoincrement = autoincrement;
 		}
 
 		MCFWriteReg32( dev, BDMDATA1, address_to_read );
-		MCFWriteReg32( dev, DMCOMMAND, 0x00240000 ); // Execute.
+		if( !iss->no_autoexec )
+			MCFWriteReg32( dev, DMCOMMAND, 0x00240000 ); // Execute.
 
 		iss->statetag = STTAG( "RDSQ" );
 		iss->currentstateval = address_to_read;
@@ -767,12 +1027,39 @@ static int ReadWord( struct SWIOState * iss, uint32_t address_to_read, uint32_t 
 	if( iss->autoincrement )
 		iss->currentstateval += 4;
 
+	if( iss->no_autoexec ) {
+		MCFWriteReg32( dev, DMCOMMAND, 0x00240000 );
+	}
+
 	// Only an issue if we are curising along very fast.
 	int r = WaitForDoneOp( dev );
 	if( r ) return r;
 
 	r = MCFReadReg32( dev, BDMDATA0, data );
 	return r;
+}
+
+static int WriteByte( struct SWIOState * iss, uint32_t address_to_write, uint8_t data )
+{
+	struct SWIOState * dev = iss;
+	int ret = 0;
+	iss->statetag = STTAG( "XXXX" );
+
+	MCFWriteReg32( dev, DMABSTRACTAUTO, 0x00000000 ); // Disable Autoexec.
+
+	// Different address, so we don't need to re-write all the program regs.
+	// sh x8,0(x9)  // Write to the address.
+	MCFWriteReg32( dev, DMPROGBUF0, 0x00848023 ); // sb x8, 0(x9)
+	MCFWriteReg32( dev, DMPROGBUF1, 0x00100073 ); // c.ebreak
+
+	MCFWriteReg32( dev, BDMDATA0, address_to_write );
+	MCFWriteReg32( dev, DMCOMMAND, 0x00231009 ); // Copy data to x9
+	MCFWriteReg32( dev, BDMDATA0, data );
+	MCFWriteReg32( dev, DMCOMMAND, 0x00271008 ); // Copy data to x8, and execute program.
+
+	ret |= WaitForDoneOp( dev );
+	iss->currentstateval = -1;
+	return ret;
 }
 
 static int WriteWord( struct SWIOState * iss, uint32_t address_to_write, uint32_t data )
@@ -810,17 +1097,21 @@ static int WriteWord( struct SWIOState * iss, uint32_t address_to_write, uint32_
 			// c.sw x8,0(x9)  // Write to the address.
 			// c.addi x9, 4
 			MCFWriteReg32( dev, DMPROGBUF1, 0x0491c080 );
-			// c.sw x9,0(x11)
-			// c.nop
-			MCFWriteReg32( dev, DMPROGBUF2, 0x0001c184 );
-			// We don't shorthand the stop here, because if we are flipping beteen flash and
-			// non-flash writes, we don't want to keep messing with these registers.
 		}
 
-		if( is_flash )
+		if( is_flash && iss->target_chip_type == CHIP_CH32V10x)
+		{
+			// Special 16 bytes buffer write sequence for CH32V103
+			MCFWriteReg32( dev, DMPROGBUF2, 0x0001c184 ); // c.sw x9,0(x11); c.nop;
+			MCFWriteReg32( dev, DMPROGBUF3, 0x9002e391 ); // c.bnez x15, 4; c.ebreak;
+			MCFWriteReg32( dev, DMPROGBUF4, 0x4200c254 ); // c.sw x13,4(x12); c.lw x8,0(x12);
+			MCFWriteReg32( dev, DMPROGBUF5, 0xfc758805 ); // c.andi x8, 1; c.bnez x8, -4;
+			MCFWriteReg32( dev, DMPROGBUF6, 0x90024781 ); // c.li x15, 0; c.ebreak;
+		}
+		else if( is_flash )
 		{
 			// A little weird - we need to wait until the buf load is done here to continue.
-			// x12 = 0x40022010 (FLASH_STATR)
+			// x12 = 0x4002200C (FLASH_STATR)
 			//
 			// c254 c.sw x13,4(x12) // Acknowledge the page write.  (BUT ONLY ON x035 / v003)
 			//  otherwise c.nop
@@ -829,8 +1120,11 @@ static int WriteWord( struct SWIOState * iss, uint32_t address_to_write, uint32_
 			//  8805 c.andi x8, 1    // Only look at BSY if we're not on a v30x / v20x
 			// fc75 c.bnez x8, -4
 			// c.ebreak
+			MCFWriteReg32( dev, DMPROGBUF2, 0x0001c184 );
 			MCFWriteReg32( dev, DMPROGBUF3, 
-				(iss->target_chip_type == CHIP_CH32X03x || iss->target_chip_type == CHIP_CH32V003 || (iss->target_chip_type >= CHIP_CH32V002 && iss->target_chip_type <= CHIP_CH32V006 ) ) ? 
+				(iss->target_chip_type == CHIP_CH32V003 || iss->target_chip_type == CHIP_CH32V00x
+				 || iss->target_chip_type == CHIP_CH32X03x || iss->target_chip_type == CHIP_CH32L10x
+				 || iss->target_chip_type == CHIP_CH641 || iss->target_chip_type == CHIP_CH643) ?
 				0x4200c254 : 0x42000001  );
 
 			MCFWriteReg32( dev, DMPROGBUF4,
@@ -841,13 +1135,17 @@ static int WriteWord( struct SWIOState * iss, uint32_t address_to_write, uint32_
 		}
 		else
 		{
-			MCFWriteReg32( dev, DMPROGBUF3, 0x90029002 ); // c.ebreak (nothing needs to be done if not flash)
+			MCFWriteReg32( dev, DMPROGBUF2, 0x9002c184 ); // c.sw x9,0(x11); c.ebreak;
 		}
 
 		MCFWriteReg32( dev, BDMDATA1, address_to_write );
 		MCFWriteReg32( dev, BDMDATA0, data );
 
-		if( did_disable_req )
+		if( iss->no_autoexec )
+		{
+			MCFWriteReg32( dev, DMCOMMAND, 0x00240000 ); // Execute.
+		}
+		else if( did_disable_req )
 		{
 			MCFWriteReg32( dev, DMCOMMAND, 0x00240000 ); // Execute.
 			MCFWriteReg32( dev, DMABSTRACTAUTO, 1 ); // Enable Autoexec.
@@ -865,6 +1163,10 @@ static int WriteWord( struct SWIOState * iss, uint32_t address_to_write, uint32_
 			MCFWriteReg32( dev, BDMDATA1, address_to_write );
 		}
 		MCFWriteReg32( dev, BDMDATA0, data );
+		if( iss->no_autoexec )
+		{
+			MCFWriteReg32( dev, DMCOMMAND, 0x00240000 ); // Execute.
+		}
 	}
 	if( is_flash )
 		ret |= WaitForDoneOp( dev );
@@ -878,7 +1180,7 @@ static int UnlockFlash( struct SWIOState * iss )
 {
 	struct SWIOState * dev = iss;
 
-	if( DetermineChipTypeAndSectorInfo( iss ) ) return -9;
+	if( DetermineChipTypeAndSectorInfo( iss, NULL ) ) return -9;
 
 	uint32_t rw;
 	ReadWord( dev, 0x40022010, &rw );  // FLASH->CTLR = 0x40022010
@@ -954,14 +1256,13 @@ static int EraseFlash( struct SWIOState * iss, uint32_t address, uint32_t length
 	return 0;
 }
 
-
-static int Write64Block( struct SWIOState * iss, uint32_t address_to_write, uint8_t * blob )
+static int WriteBlock( struct SWIOState * iss, uint32_t address_to_write, uint8_t * blob, uint8_t len, uint8_t erase )
 {
 	struct SWIOState * dev = iss;
 
-	if( DetermineChipTypeAndSectorInfo( iss ) ) return -9;
+	if( DetermineChipTypeAndSectorInfo( iss, NULL ) ) return -9;
 
-	const int blob_size = 64;
+	const int blob_size = len;
 	uint32_t wp = address_to_write;
 	uint32_t ew = wp + blob_size;
 	int group = -1;
@@ -983,18 +1284,21 @@ static int Write64Block( struct SWIOState * iss, uint32_t address_to_write, uint
 
 		is_flash = 1;
 
-		// Only erase on first block in sector.
-		int block_in_sector = (wp & ( iss->sectorsize - 1 )) / blob_size;
-		int is_first_block = block_in_sector == 0;
-
-		if( is_first_block )
+		if( erase )
 		{
-			rw = EraseFlash( dev, address_to_write, blob_size, 0 );
-			if( rw ) return rw;
-			// 16.4.6 Main memory fast programming, Step 5
-			//if( WaitForFlash( dev ) ) return -11;
-			//WriteWord( dev, 0x40022010, FLASH_CTLR_BUF_RST );
-			//if( WaitForFlash( dev ) ) return -11;
+			// Only erase on first block in sector.
+			int block_in_sector = (wp & ( iss->sectorsize - 1 )) / blob_size;
+			int is_first_block = block_in_sector == 0;
+
+			if( is_first_block )
+			{
+				rw = EraseFlash( dev, address_to_write, blob_size, 0 );
+				if( rw ) return rw;
+				// 16.4.6 Main memory fast programming, Step 5
+				//if( WaitForFlash( dev ) ) return -11;
+				//WriteWord( dev, 0x40022010, FLASH_CTLR_BUF_RST );
+				//if( WaitForFlash( dev ) ) return -11;
+			}
 		}
 	}
 
@@ -1031,7 +1335,7 @@ static int Write64Block( struct SWIOState * iss, uint32_t address_to_write, uint
 			}
 
 			int j;
-			for( j = 0; j < 16; j++ )
+			for( j = 0; j < blob_size/4; j++ )
 			{
 				int index = (wp-address_to_write);
 				uint32_t data = 0xffffffff;
@@ -1042,6 +1346,12 @@ static int Write64Block( struct SWIOState * iss, uint32_t address_to_write, uint
 				else if( (int32_t)(blob_size - index) > 0 )
 				{
 					memcpy( &data, &blob[index], blob_size - index );
+				}
+				if( iss->target_chip_type == CHIP_CH32V10x && !((j+1)&3) )
+				{
+					// Signal to WriteWord that we need to do a buffer load
+					MCFWriteReg32( dev, BDMDATA0, 1 );
+					MCFWriteReg32( dev, DMCOMMAND, 0x0023100f );
 				}
 				WriteWord( dev, wp, data );
 				wp += 4;
@@ -1056,12 +1366,10 @@ static int Write64Block( struct SWIOState * iss, uint32_t address_to_write, uint
 					if( WaitForFlash( dev ) ) return -13;
 				}
 			}
-			else // TODO: What about the v10x?
+			else
 			{
 				// Datasheet says the x03x needs to have this called every group-of-16, but that's not true, it should be every 16-words.
-
 				WriteWord( dev, 0x40022014, group );  //0x40022014 -> FLASH->ADDR
-				//if( MCF.PrepForLongOp ) MCF.PrepForLongOp( dev );  // Give the programmer a headsup this next operation could take a while.
 				WriteWord( dev, 0x40022010, CR_PAGE_PG|CR_STRT_Set ); // 0x40022010 -> FLASH->CTLR
 				if( WaitForFlash( dev ) ) return -16;
 			}
@@ -1138,4 +1446,3 @@ static int PollTerminal( struct SWIOState * iss, uint8_t * buffer, int maxlen, u
 }
 
 #endif // _CH32V003_SWIO_H
-

--- a/rvswdio_programmer/ch5xx.c
+++ b/rvswdio_programmer/ch5xx.c
@@ -5,7 +5,6 @@
 */
 
 #include "ch5xx.h"
-#include "ch32fun.h"
 #include "ch5xx.h"
 #include "bitbang_rvswdio.h"
 
@@ -651,7 +650,7 @@ int ch5xx_microblob_init(struct SWIOState * iss, uint32_t start_addr) {
 	
 	MCFWriteReg32(dev, BDMDATA1, 1);
 	MCFWriteReg32(dev, DMCONTROL, 0x40000001);
-	if (iss->target_chip_type == CHIP_CH570) MCFWriteReg32(dev, DMCONTROL, 0x40000001);
+	if (iss->target_chip_type == CHIP_CH570 || iss->target_chip_type == CHIP_CH585) MCFWriteReg32(dev, DMCONTROL, 0x40000001);
 
 	MCFWriteReg32(dev, BDMDATA0, 0);
 	MCFWriteReg32(dev, BDMDATA1, 0);

--- a/rvswdio_programmer/ch5xx.c
+++ b/rvswdio_programmer/ch5xx.c
@@ -1,0 +1,949 @@
+/*
+	Set of functions to program CH5xx series of chips by WCH.
+	For use with rv003usb rvswdio programmer.
+	Copyright 2025 monte-monte
+*/
+
+#include "ch5xx.h"
+#include "ch32fun.h"
+#include "ch5xx.h"
+#include "bitbang_rvswdio.h"
+
+// Assembly for these binary blobs can be found it the attic folder
+unsigned char ch5xx_write_block_bin[] = {
+	0x80, 0x41, 0xc4, 0x41, 0xe3, 0x9e, 0x84, 0xfe, 0x65, 0xfc, 0x1a, 0x85,
+	0x23, 0x83, 0x06, 0x00, 0x15, 0x47, 0x23, 0x83, 0xe6, 0x00, 0x19, 0x47,
+	0x23, 0x82, 0xe6, 0x00, 0x03, 0x87, 0x66, 0x00, 0xe3, 0x4e, 0x07, 0xfe,
+	0x23, 0x83, 0x06, 0x00, 0x23, 0x83, 0x06, 0x00, 0x15, 0x47, 0x23, 0x83,
+	0xe6, 0x00, 0x09, 0x47, 0x23, 0x82, 0xe6, 0x00, 0x0d, 0x46, 0x93, 0x52,
+	0x05, 0x01, 0x93, 0xf2, 0xf2, 0x0f, 0x03, 0x87, 0x66, 0x00, 0xe3, 0x4e,
+	0x07, 0xfe, 0x23, 0x82, 0x56, 0x00, 0x22, 0x05, 0x7d, 0x16, 0x65, 0xf6,
+	0x23, 0xa0, 0x05, 0x00, 0x93, 0x07, 0x00, 0x04, 0x80, 0x41, 0xc4, 0x41,
+	0xb5, 0xec, 0x6d, 0xdc, 0x80, 0xc2, 0x11, 0x47, 0x03, 0x86, 0x66, 0x00,
+	0xe3, 0x4e, 0x06, 0xfe, 0x55, 0x46, 0x23, 0x83, 0xc6, 0x00, 0x7d, 0x17,
+	0x65, 0xfb, 0xfd, 0x17, 0x23, 0xa0, 0x05, 0x00, 0xf1, 0xff, 0x13, 0x03,
+	0x03, 0x10, 0x23, 0xa0, 0x65, 0x00, 0xb7, 0x02, 0x08, 0x00, 0x03, 0x87,
+	0x66, 0x00, 0xe3, 0x4e, 0x07, 0xfe, 0x23, 0x83, 0x06, 0x00, 0x23, 0x83,
+	0x06, 0x00, 0x15, 0x47, 0x23, 0x83, 0xe6, 0x00, 0x23, 0x82, 0xe6, 0x00,
+	0x03, 0x87, 0x66, 0x00, 0xe3, 0x4e, 0x07, 0xfe, 0x03, 0xc6, 0x46, 0x00,
+	0x03, 0x87, 0x66, 0x00, 0xe3, 0x4e, 0x07, 0xfe, 0x03, 0x86, 0x46, 0x00,
+	0x03, 0x87, 0x66, 0x00, 0xe3, 0x4e, 0x07, 0xfe, 0x23, 0x83, 0x06, 0x00,
+	0x13, 0x77, 0x16, 0x00, 0x11, 0xe3, 0x25, 0xbf, 0xfd, 0x12, 0xe3, 0x92,
+	0x02, 0xfc, 0x02, 0x90, 0x23, 0xa2, 0x05, 0x00, 0xe3, 0x87, 0xb4, 0xfa,
+	0x23, 0xa0, 0x06, 0x00, 0x11, 0x47, 0xbd, 0xbf
+};
+unsigned int ch5xx_write_block_bin_len = 236;
+
+// By default all chips run at the lowest possible frequency. (For example CH585 runs at 5.33MHz)
+// Some of them needs to set it higher to be able to be programmed reliably.
+// WCH-LinkE sets needed frequency automatically with it's built-in functions. But it will be reset if we reset the chip.
+// Also we still need to do that every time we use other programmers.
+int ch5xx_set_clock(struct SWIOState * iss, uint32_t clock) {
+	struct SWIOState * dev = iss;
+	int r = 0;
+	if (clock == 0) {
+		uint32_t rr = 0;
+		r = MCFReadWord(dev, 0x40001008, &rr);
+		switch (iss->target_chip_type)
+		{
+		case CHIP_CH585:
+			iss->clock_set = 24000;
+			if ((rr&0x1f) == 3) {
+				ch5xx_write_safe(dev, 0x4000100A, 0x16, 0);
+				ch5xx_write_safe(dev, 0x40001008, 0x14d, 1);
+			} else {
+				return r;
+			}
+			break;
+
+		case CHIP_CH570:
+			iss->clock_set = 75000;
+			if ((rr&0xff) == 5) {
+				ch5xx_write_safe(dev, 0x4000100A, 0x14, 0); // Enable PLL
+				// Set flash clock (undocumented)
+				ch5xx_write_safe(dev, 0x40001805, 0x8, 0); // Flash SCK 50MHz
+				ch5xx_write_safe(dev, 0x40001807, 0x1, 0); // Flash CFG something about clock source (PLL)
+				// Set core clock
+				ch5xx_write_safe(dev, 0x40001008, 0x48, 0); // 75MHz
+				// Disable watchdog
+				MCFWriteWord(dev, 0x40001000, 0x5555);
+				MCFWriteWord(dev, 0x40001004, 0x7fff);
+			} else {
+				return r;
+			}
+			break;
+
+		case CHIP_CH57x:
+		case CHIP_CH58x:
+		case CHIP_CH59x:
+			iss->clock_set = 16000;
+			if ((rr&0xff) == 5) {
+				ch5xx_write_safe(dev, 0x40001008, 0x82, 0);
+			} else {
+				return r;
+			}
+			break;
+		
+		default:
+			return 0;
+		}
+	}
+	return r;
+}
+
+// Some critical registers of CH5xx are only writeable in "safe mode", this requires a special procedure.
+// Such registers marked "RWA" in the datasheet
+void ch5xx_write_safe(struct SWIOState * iss, uint32_t addr, uint32_t value, uint8_t mode) {
+	struct SWIOState * dev = iss;
+
+	if ((iss->statetag & 0xFFFF00FF) != (STTAG( "5WWS" ) &0xFFFF00FF)) {
+		MCFWriteReg32(dev, DMABSTRACTAUTO, 0x00000000); // Disable Autoexec.
+
+		MCFWriteReg32(dev, BDMDATA0, 0x40001040);
+		MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100d); // Write a3 from DATA0.
+		MCFWriteReg32(dev, BDMDATA0, 0x57);
+		MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100e); // Write a4 from DATA0.
+		MCFWriteReg32(dev, BDMDATA0, 0xa8);
+		MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100f); // Write a5 from DATA0.
+
+		MCFWriteReg32(dev, DMPROGBUF0, 0x00e68023); // sb  a4,0x0(a3)
+		MCFWriteReg32(dev, DMPROGBUF1, 0x00f68023); // sb  a5,0x0(a3)
+		MCFWriteReg32(dev, DMPROGBUF2, 0x00010001); // c.nop c.nop
+		MCFWriteReg32(dev, DMPROGBUF4, 0x00100073); // c.ebreak	
+	}
+
+	if (mode == 0 && iss->statetag != STTAG( "5WBS" )) {
+		MCFWriteReg32(dev, DMPROGBUF3, 0x00c28023); // sb  a2,0x0(t0)
+		iss->statetag = STTAG( "5WBS" );
+	} else if (mode == 1 && iss->statetag != STTAG( "5WHS" )) {
+		MCFWriteReg32(dev, DMPROGBUF3, 0x00c29023); // sh  a2,0x0(t0)  
+		iss->statetag = STTAG( "5WHS" );
+	} else if (mode == 2 && iss->statetag != STTAG( "5WBS" )) {
+		MCFWriteReg32(dev, DMPROGBUF3, 0x00c2a023); // sw  a2,0x0(t0)  
+		iss->statetag = STTAG( "5WWS" );
+	}
+
+	MCFWriteReg32(dev, BDMDATA0, addr);
+	MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x1005); // Write t0 from DATA0.
+	MCFWriteReg32(dev, BDMDATA0, value);
+	MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100c); // Write a2 from DATA0.
+
+	MCFWriteReg32(dev, DMCOMMAND, 0x00271000); // Execute program.
+
+	MCFWaitForDoneOp(dev);
+	iss->currentstateval = -1;
+
+}
+
+uint8_t ch5xx_flash_begin(struct SWIOState * iss, uint8_t cmd) {
+	struct SWIOState * dev = iss;
+
+	if (iss->statetag != STTAG("FBEG")) {
+		if ((iss->statetag & 0xff) != 'F') {
+			MCFWriteReg32(dev, DMABSTRACTAUTO, 0x00000000); // Disable Autoexec.
+			MCFWriteReg32(dev, BDMDATA0, R32_FLASH_DATA);
+			MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100d); // Write a3 from DATA0.
+		}
+		MCFWriteReg32(dev, DMPROGBUF0, 0x00068323); // sb zero,6(a3);
+		MCFWriteReg32(dev, DMPROGBUF1, 0x00014715); // c.li a4,5; c.nop;
+		MCFWriteReg32(dev, DMPROGBUF2, 0x00e68323); // sb a4,6(a3);
+		MCFWriteReg32(dev, DMPROGBUF3, 0x00f68223); // sb a5,4(a3);
+		MCFWriteReg32(dev, DMPROGBUF4, 0x00100073); // c.ebreak
+
+		iss->statetag = STTAG("FBEG");  
+	}
+
+	MCFWriteReg32(dev, BDMDATA0, cmd); // Write command to a5
+	MCFWriteReg32(dev, DMCOMMAND, 0x0027100f); // Execute program.
+	
+	return cmd;
+}
+
+void ch5xx_flash_end(struct SWIOState * iss) {
+	struct SWIOState * dev = iss;
+
+	if (iss->statetag != STTAG("FEND")) {
+		if ((iss->statetag & 0xff) != 'F') {
+			MCFWriteReg32(dev, DMABSTRACTAUTO, 0x00000000); // Disable Autoexec.
+			MCFWriteReg32(dev, BDMDATA0, R32_FLASH_DATA);
+			MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100d); // Write a3 from DATA0.
+		}
+		MCFWriteReg32(dev, DMPROGBUF0, 0x00668703); // lb a4,6(a3);
+		MCFWriteReg32(dev, DMPROGBUF1, 0xfe074ee3); // blt a4,zero,-4;
+		MCFWriteReg32(dev, DMPROGBUF2, 0x00068323); // sb zero,6(a3);
+		MCFWriteReg32(dev, DMPROGBUF3, 0x00100073); // c.ebreak
+
+		iss->statetag = STTAG("FEND");  
+	}
+
+	MCFWriteReg32(dev, DMCOMMAND, 0x00271000); // Execute program.
+}
+
+void ch5xx_flash_out(struct SWIOState * iss, uint8_t addr)
+{
+	struct SWIOState * dev = iss;
+
+	if (iss->statetag != STTAG("FOUT")) {
+		if ((iss->statetag & 0xff) != 'F') {
+			MCFWriteReg32(dev, DMABSTRACTAUTO, 0x00000000); // Disable Autoexec.
+			MCFWriteReg32(dev, BDMDATA0, R32_FLASH_DATA);
+			MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100d); // Write a3 from DATA0.
+		}
+		MCFWriteReg32(dev, DMPROGBUF0, 0x00668703); // lb a4,6(a3);
+		MCFWriteReg32(dev, DMPROGBUF1, 0xfe074ee3); // blt a4,zero,-4;
+		MCFWriteReg32(dev, DMPROGBUF2, 0x00f68223); // sb a5,4(a3);
+		MCFWriteReg32(dev, DMPROGBUF3, 0x00100073); // c.ebreak
+
+		iss->statetag = STTAG("FOUT");  
+	}
+
+	MCFWriteReg32(dev, BDMDATA0, addr); // Write command to a4
+	MCFWriteReg32(dev, DMCOMMAND, 0x0027100f); // Execute program.
+	
+}
+
+uint8_t ch5xx_flash_in(struct SWIOState * iss)
+{
+	struct SWIOState * dev = iss;
+	uint8_t r;
+
+	if (iss->statetag != STTAG("FLIN")) {
+		if ((iss->statetag & 0xff) != 'F') {
+			MCFWriteReg32(dev, DMABSTRACTAUTO, 0x00000000); // Disable Autoexec.
+			MCFWriteReg32(dev, BDMDATA0, R32_FLASH_DATA);
+			MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100d); // Write a3 from DATA0.
+		}
+		MCFWriteReg32(dev, DMPROGBUF0, 0x00668703); // lb a4,6(a3);
+		MCFWriteReg32(dev, DMPROGBUF1, 0xfe074ee3); // blt a4,zero,-4;
+		MCFWriteReg32(dev, DMPROGBUF2, 0x00468783); // lb a5,4(a3);
+		MCFWriteReg32(dev, DMPROGBUF3, 0x00100073); // c.ebreak
+
+		iss->statetag = STTAG( "FLIN" );  
+	}
+
+	MCFWriteReg32(dev, DMCOMMAND, 0x00271000); // Execute program.
+	
+	r = MCFWaitForDoneOp(dev);
+	if (r) return 0;
+
+	uint32_t rr;
+	MCFWriteReg32(dev, DMCOMMAND, 0x0022100f); // Read a5 into DATA0.
+	MCFReadReg32(dev, BDMDATA0, &rr);
+	r = rr & 0xff;
+	
+	return r;
+}
+
+uint8_t ch5xx_flash_addr(struct SWIOState * iss, uint8_t cmd, uint32_t addr) {
+  struct SWIOState * dev = iss;
+	uint8_t ret;
+	int len = 5;
+
+	if ((cmd & 0xbf) != 0xb) {
+		ch5xx_flash_begin(dev, 6);
+		ch5xx_flash_end(dev);
+		
+		len = 3;
+	}
+	ret = ch5xx_flash_begin(dev, cmd);
+	while (len--, len != -1) {
+		ch5xx_flash_out(dev, (addr >> 16) & 0xff);
+		addr = addr << 8;
+	}
+	return ret;
+}
+
+uint8_t ch5xx_flash_open(struct SWIOState * iss, uint8_t op) {
+	struct SWIOState * dev = iss;
+
+	uint8_t glob_rom_cfg;
+	MCFReadByte(dev, 0x40001044, &glob_rom_cfg);
+	// //fprintf(stderr, "RS = %02x, op = %02x\n", glob_rom_cfg, op);
+	if ((glob_rom_cfg & 0xe0) != op) {
+		ch5xx_write_safe(dev, 0x40001044, op, 0);
+		MCFReadByte(dev, 0x40001044, &glob_rom_cfg);
+		// //fprintf(stderr, "RS = %02x\n", glob_rom_cfg);
+	}
+	MCFWriteByte(dev, 0x40001806, 4);
+	if (iss->target_chip_type == CHIP_CH570){
+		ch5xx_flash_begin(dev, 0xff);
+		ch5xx_flash_out(dev, 0xff);
+		ch5xx_flash_in(dev);
+	} else {
+		ch5xx_flash_begin(dev, 0xff);
+	}
+	ch5xx_flash_end(dev);
+	return glob_rom_cfg;
+}
+
+void ch5xx_flash_close(struct SWIOState * iss) {
+	struct SWIOState * dev = iss;
+	uint8_t glob_rom_cfg;
+	MCFReadByte(dev, 0x40001044, &glob_rom_cfg);
+	ch5xx_flash_end(dev);
+	ch5xx_write_safe(dev, 0x40001044, glob_rom_cfg & 0x10, 0);
+}
+
+uint8_t ch5xx_flash_wait(struct SWIOState * iss) {
+	struct SWIOState * dev = iss;
+	uint32_t timer = 0x80000;
+	uint8_t ret = 0;
+	ch5xx_flash_end(dev);
+	// //fprintf(stderr, "1\n");
+	do {
+		// //fprintf(stderr, "%d\n", timer);
+		ch5xx_flash_begin(dev, 5);
+		ch5xx_flash_in(dev);
+		ret = ch5xx_flash_in(dev);
+		ch5xx_flash_end(dev);
+		if ((ret & 1) == 0) {
+			return (ret & 0xff) | 1;
+		}
+		// MCFDelayUS(dev, 100);
+		timer--;
+	} while (timer != 0);
+	return 0;
+}
+
+int ch5xx_read_eeprom(struct SWIOState * iss, uint32_t addr, uint8_t* buffer, uint32_t len) {
+	struct SWIOState * dev = iss;
+
+	enum RiscVChip chip = iss->target_chip_type;
+	uint32_t rrv;
+	int r;
+
+	ch5xx_flash_open(dev, 0x20);
+
+	if (chip == CHIP_CH57x ||
+			chip == CHIP_CH58x ||
+			chip == CHIP_CH585 ||
+			chip == CHIP_CH59x)
+	{
+		ch5xx_flash_addr(dev, 0xb, (addr | 0x80000));
+	} else if (chip == CHIP_CH570) {
+		//fprintf(stderr, "CH570/2 don't have EEPROM\n");
+		return -1;
+	}
+
+	if (iss->statetag != STTAG("FREP")) {
+		if ((iss->statetag & 0xff) != 'F') {
+			MCFWriteReg32(dev, DMABSTRACTAUTO, 0x00000000); // Disable Autoexec.
+			MCFWriteReg32(dev, BDMDATA0, R32_FLASH_DATA);
+			MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100d); // Write a3 from DATA0.
+		}
+
+		MCFWriteReg32(dev, DMPROGBUF0, 0x00668703); // lb a4,6(a3);
+		MCFWriteReg32(dev, DMPROGBUF1, 0xfe074ee3); // blt a4,zero,-4;
+		MCFWriteReg32(dev, DMPROGBUF2, 0x00468583); // lb a1,4(a3);
+		MCFWriteReg32(dev, DMPROGBUF7, 0xfe5ff06f); // jal zero,-28
+		iss->statetag = STTAG("FREP");
+	}
+	
+	for (int i = 0; i < len; i++) {
+		uint32_t local_buffer = 0;
+		MCFWriteReg32(dev, DMCOMMAND, 0x00271000); // Execute program.
+		do {
+			r = MCFReadReg32(dev, DMABSTRACTCS, &rrv);
+			if(r) return r;
+			if (rrv & (0x700)) {
+				//fprintf(stderr, "Error in ch5xx_read_eeprom: %08x\n", rrv);
+				return rrv;
+			}
+		} while((rrv & (1<<12)));
+		MCFWriteReg32(dev, DMCOMMAND, 0x0022100b); // Read a0 into DATA0.
+		MCFReadReg32(dev, BDMDATA0, &local_buffer);
+		*(buffer + i) = local_buffer & 0xff;
+	}
+	
+	ch5xx_flash_close(dev);
+	return 0;
+}
+
+int ch5xx_read_options(struct SWIOState * iss, uint32_t addr, uint8_t* buffer) {
+	struct SWIOState * dev = iss;
+
+	enum RiscVChip chip = iss->target_chip_type;
+
+	ch5xx_flash_open(dev, 0x20);
+
+	if (chip == CHIP_CH57x ||
+			chip == CHIP_CH58x ||
+			chip == CHIP_CH585 ||
+			chip == CHIP_CH59x)
+	{
+		ch5xx_flash_addr(dev, 0xb, (addr | 0x80000));
+	} else if (chip == CHIP_CH570) {
+		ch5xx_flash_addr(dev, 0xb, addr);
+	}
+
+	if (iss->statetag != STTAG("FOPT")) {
+		if ((iss->statetag & 0xff) != 'F') {
+			MCFWriteReg32(dev, DMABSTRACTAUTO, 0x00000000); // Disable Autoexec.
+			MCFWriteReg32(dev, BDMDATA0, R32_FLASH_DATA);
+			MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100d); // Write a3 from DATA0.
+		}
+		MCFWriteReg32(dev, BDMDATA0, 4);
+		MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100f); // Write a5 from DATA0
+		MCFWriteReg32(dev, BDMDATA0, 8);
+		MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100c); // Write a2 from DATA0
+
+		MCFWriteReg32(dev, DMPROGBUF0, 0x00668703); // lb a4,6(a3);
+		MCFWriteReg32(dev, DMPROGBUF1, 0xfe074ee3); // blt a4,zero,-4;
+		MCFWriteReg32(dev, DMPROGBUF2, 0x00468583); // lb a1,4(a3);
+		MCFWriteReg32(dev, DMPROGBUF3, 0xc9e3167d); // c.addi a2,-1; blt a5,a2,-14 [0xfec7c9e3]
+		MCFWriteReg32(dev, DMPROGBUF4, 0xe219fec7); //               c.bnez a2,6
+		MCFWriteReg32(dev, DMPROGBUF5, 0x9002428c); // c.lw a1,0(a3) c.ebrake 
+		MCFWriteReg32(dev, DMPROGBUF6, 0x17f14288); // c.lw a0,0(a3) c.addi a5,-4
+		MCFWriteReg32(dev, DMPROGBUF7, 0xfe5ff06f); // jal zero,-28
+		iss->statetag = STTAG("FOPT");
+	}
+	
+	MCFWriteReg32(dev, DMCOMMAND, 0x00271000); // Execute program.
+	
+	uint32_t rrv;
+	int r;
+	do {
+		r = MCFReadReg32(dev, DMABSTRACTCS, &rrv);
+		if(r) return r;
+		if (rrv & (0x700)) {
+			//fprintf(stderr, "Error in ch5xx_read_options: %08x\n", rrv);
+			return rrv;
+		}
+	} while((rrv & (1<<12)));
+	
+	MCFWriteReg32(dev, DMCOMMAND, 0x0022100a); // Read a0 into DATA0.
+	MCFReadReg32(dev, BDMDATA0, (uint32_t*)buffer);
+	MCFWriteReg32(dev, DMCOMMAND, 0x0022100b); // Read a1 into DATA0.
+	MCFReadReg32(dev, BDMDATA0, (uint32_t*)(buffer+4));
+
+	ch5xx_flash_close(dev);
+	return 0;
+}
+
+int ch5xx_read_options_bulk(struct SWIOState * iss, uint32_t addr, uint8_t* buffer, uint32_t len) {
+	struct SWIOState * dev = iss;
+
+	enum RiscVChip chip = iss->target_chip_type;
+
+	int r;
+	uint32_t dmdata0;
+
+	uint32_t dmdata0_offset = 0xe0000380;
+	MCFReadReg32(dev, DMHARTINFO, &dmdata0_offset);
+	dmdata0_offset = 0xe0000000 | (dmdata0_offset & 0x7ff);
+
+	ch5xx_flash_open(dev, 0x20);
+
+	if (chip == CHIP_CH57x ||
+			chip == CHIP_CH58x ||
+			chip == CHIP_CH585 ||
+			chip == CHIP_CH59x)
+	{
+		ch5xx_flash_addr(dev, 0xb, (addr | 0x80000));
+	} else if (chip == CHIP_CH570) {
+		ch5xx_flash_addr(dev, 0xb, (addr | 0x40000));
+	}
+	
+	if (iss->statetag != STTAG("FOPB") || iss->statetag != STTAG("FVER")) {
+		if ((iss->statetag & 0xff) != 'F') {
+			MCFWriteReg32(dev, DMABSTRACTAUTO, 0x00000000); // Disable Autoexec.
+			MCFWriteReg32(dev, BDMDATA0, R32_FLASH_DATA);
+			MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100d); // Write a3 from DATA0.
+		}
+		MCFWriteReg32(dev, BDMDATA0, dmdata0_offset);
+		MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100a); // Write a0 from DATA0.
+
+		MCFWriteReg32(dev, DMPROGBUF0, 0x47910001); // c.nop; li a5,4;
+		MCFWriteReg32(dev, DMPROGBUF1, 0x00668703); // lb a4,6(a3);
+		MCFWriteReg32(dev, DMPROGBUF2, 0xfe074ee3); // blt a4,zero,-4;
+		MCFWriteReg32(dev, DMPROGBUF3, 0x00468703); // lb a4,4(a3);
+		MCFWriteReg32(dev, DMPROGBUF4, 0xfbed17fd); // c.addi a5,-1; c.bnez a5,-14;
+		MCFWriteReg32(dev, DMPROGBUF5, 0xc10c428c); // c.lw a1,0(a3); c.sw a1,0,(a0);
+		MCFWriteReg32(dev, DMPROGBUF6, 0x00100073); // ebreak
+
+		iss->statetag = STTAG("FOPB");
+	}
+
+for (int i = 0; i < len; i += 4) {
+		uint8_t timeout = 100;
+		MCFWriteReg32(dev, DMCOMMAND, 0x00271000); // Execute program.
+		do {
+			r = MCFReadReg32(dev, DMABSTRACTCS, &dmdata0);
+			if(r) return r;
+			if (dmdata0 & (0x700)) {
+				//fprintf(stderr, "Error in ch5xx_read_option_bulk: %08x\n", dmdata0);
+				return -2;
+			}
+			timeout--;
+		} while((dmdata0 & (1<<12)) && timeout);
+		MCFReadReg32(dev, BDMDATA0, (uint32_t*)(buffer + i));
+	}
+
+	ch5xx_flash_close(dev);
+	return 0;
+}
+
+// On some of CH5xx chips (CH592 for example) there is mysterious second UUID.
+// What's the purpose of it? It's not documented, it's only mentioned with the function that reads it.
+int ch5xx_read_secret_uuid(struct SWIOState * iss, uint8_t * buffer) {
+	struct SWIOState * dev = iss;
+	if(!iss->target_chip_type) {
+		MCFDetermineChipType(dev);
+	}
+
+	iss->statetag = STTAG("5SID");
+
+	uint8_t local_buffer[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+	
+	uint32_t dmdata0_offset = 0xe0000380;
+	MCFReadReg32(dev, DMHARTINFO, &dmdata0_offset);
+	dmdata0_offset = 0xe0000000 | (dmdata0_offset & 0x7ff);
+
+	ch5xx_flash_open(dev, 0x20);
+	ch5xx_flash_addr(dev, 0x4b, 0);
+	
+	MCFWriteReg32(dev, BDMDATA0, 0xffffffff);
+	MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x1005); // Write t0 from DATA0
+	MCFWriteReg32(dev, BDMDATA0, dmdata0_offset);
+	MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100a); // Write a0 from DATA0
+	MCFWriteReg32(dev, BDMDATA0, 0xf);
+	MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100b); // Write a1 from DATA0
+	MCFWriteReg32(dev, BDMDATA0, 0);
+	MCFWriteReg32(dev, BDMDATA1, 0);
+
+	MCFWriteReg32(dev, DMPROGBUF0, 0x00668703); // lb a4,6(a3);
+	MCFWriteReg32(dev, DMPROGBUF1, 0xfe074ee3); // blt a4,zero,-4;
+	MCFWriteReg32(dev, DMPROGBUF2, 0xf79342d8); // c.lw a4,4(a3); andi a5,a1,0x7;
+	MCFWriteReg32(dev, DMPROGBUF3, 0x97aa0075); //                c.add a5,a0;
+	MCFWriteReg32(dev, DMPROGBUF4, 0x00078603); // lb a2,0x0(a5);
+	MCFWriteReg32(dev, DMPROGBUF5, 0x8f3115fd); // c.addi a1,-1; c.xor a4,a2;
+	MCFWriteReg32(dev, DMPROGBUF6, 0x00e78023); // sb a4,0(a5);
+	MCFWriteReg32(dev, DMPROGBUF7, 0x00100073); // c.ebreak
+	// MCFWriteReg32(dev, DMPROGBUF7, 0xfe5592e3); // bne a1,t0,-28;
+	// MCFWriteReg32(dev, DMCOMMAND, 0x00271000); // Execute program.
+	uint32_t rrv;
+	int r;
+	for (int i = 0xf; i > -1; i--) {
+		MCFWriteReg32(dev, DMCOMMAND, 0x00271000); // Execute program.
+		do {
+			r = MCFReadReg32(dev, DMABSTRACTCS, &rrv);
+			if(r) return r;
+			if (rrv & (0x700)) {
+				MCFWriteReg32(dev, DMABSTRACTCS, 0x08000700); // Clear out any dmabstractcs errors.
+			}
+		} while((rrv & (1<<12)));
+	}
+	MCFReadReg32(dev, BDMDATA0, (uint32_t*)local_buffer);
+	MCFReadReg32(dev, BDMDATA1, (uint32_t*)(local_buffer+4));
+
+	for (int i = 0; i < 8; i++) {
+		buffer[i] = local_buffer[i];
+	}
+	// //fprintf(stderr, "%02x-%02x-%02x-%02x-%02x-%02x-%02x-%02x\n", local_buffer[0], local_buffer[1], local_buffer[2], local_buffer[3], local_buffer[4], local_buffer[5], local_buffer[6], local_buffer[7]);
+
+	ch5xx_flash_close(dev);
+	return 0;
+}
+
+// All CH5xx have UUID which is also used to produce unique MAC address for BLE
+int ch5xx_read_uuid(struct SWIOState * iss, uint8_t * buffer) {
+	struct SWIOState * dev = iss;
+	if(!iss->target_chip_type) {
+		MCFDetermineChipType(dev);
+	}
+
+	iss->statetag = STTAG("5UID");
+
+	enum RiscVChip chip = iss->target_chip_type;
+	uint8_t local_buffer[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+
+	ch5xx_flash_open(dev, 0x20);
+
+	if (chip == CHIP_CH57x ||
+		  chip == CHIP_CH58x ||
+		  chip == CHIP_CH585 ||
+		  chip == CHIP_CH59x)
+	{
+		ch5xx_flash_addr(dev, 0xb, (0x7F018 | 0x80000));
+	} else if (chip == CHIP_CH570) {
+		ch5xx_flash_addr(dev, 0xb, (0x3F018 | 0x40000));
+	}
+	
+	MCFWriteReg32(dev, DMABSTRACTAUTO, 0x00000000); // Disable Autoexec.
+	MCFWriteReg32(dev, BDMDATA0, 4);
+	MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100f); // Write a5 from DATA0
+	MCFWriteReg32(dev, BDMDATA0, 8);
+	MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100c); // Write a2 from DATA0
+
+	MCFWriteReg32(dev, DMPROGBUF0, 0x00668703); // lb a4,6(a3);
+	MCFWriteReg32(dev, DMPROGBUF1, 0xfe074ee3); // blt a4,zero,-4;
+	MCFWriteReg32(dev, DMPROGBUF2, 0x00468583); // lb a1,4(a3);
+	MCFWriteReg32(dev, DMPROGBUF3, 0xc9e3167d); // c.addi a2,-1; blt a5,a2,-14 [0xfec7c9e3]
+	MCFWriteReg32(dev, DMPROGBUF4, 0xe219fec7); //               c.bnez a2,6
+	MCFWriteReg32(dev, DMPROGBUF5, 0x9002428c); // c.lw a1,0(a3) c.ebrake 
+	MCFWriteReg32(dev, DMPROGBUF6, 0x17f14288); // c.lw a0,0(a3) c.addi a5,-4
+	MCFWriteReg32(dev, DMPROGBUF7, 0xfe5ff06f); // jal zero,-28
+	MCFWriteReg32(dev, DMCOMMAND, 0x00271000); // Execute program.
+	
+	uint32_t rrv;
+	int r;
+	do {
+		r = MCFReadReg32(dev, DMABSTRACTCS, &rrv);
+		if(r) return r;
+		if (rrv & (0x700)) {
+			//fprintf(stderr, "Error in ch5xx_read_uuid: %08x\n", rrv);
+			return rrv;
+		}
+	} while((rrv & (1<<12)));
+	
+	MCFWriteReg32(dev, DMCOMMAND, 0x0022100a); // Read a0 into DATA0.
+	MCFReadReg32(dev, BDMDATA0, (uint32_t*)local_buffer);
+	MCFWriteReg32(dev, DMCOMMAND, 0x0022100b); // Read a1 into DATA0.
+	MCFReadReg32(dev, BDMDATA0, (uint32_t*)(local_buffer+4));
+	
+	uint16_t temp = (local_buffer[0]|(local_buffer[1]<<8)) + (local_buffer[2]|(local_buffer[3]<<8)) + (local_buffer[4]|(local_buffer[5]<<8));
+		local_buffer[6] = temp&0xFF;
+		local_buffer[7] = (temp>>8)&0xFF;
+
+	for (int i = 0; i < 8; i++) {
+		buffer[i] = local_buffer[i];
+	}
+
+	ch5xx_flash_close(dev);
+	return 0;
+}
+
+int ch5xx_microblob_init(struct SWIOState * iss, uint32_t start_addr) {
+	struct SWIOState * dev = iss;
+	int r = 0;
+	
+	uint32_t dmdata0_offset = 0xe0000380;
+	uint32_t ram_base = 0x20000000;
+	if (iss->target_chip_type == CHIP_CH57x) ram_base = 0x20003800;
+	MCFReadReg32(dev, DMHARTINFO, &dmdata0_offset);
+	dmdata0_offset = 0xe0000000 | (dmdata0_offset & 0x7ff);
+	
+	if (iss->microblob_running < -1) {
+		for (int i = 0; i < ch5xx_write_block_bin_len; i+=4) {
+			MCFWriteWord(dev, ram_base+i, *((uint32_t*)(ch5xx_write_block_bin + i)));
+		}
+	}
+
+	ch5xx_flash_open(dev, 0xe0);
+
+	if ((iss->statetag & 0xff) != 'F') {
+		MCFWriteReg32(dev, DMABSTRACTAUTO, 0x00000000); // Disable Autoexec.
+		MCFWriteReg32(dev, BDMDATA0, R32_FLASH_DATA);
+		MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100d); // Write a3 from DATA0.
+	}
+	MCFWriteReg32(dev, BDMDATA0, dmdata0_offset); // DMDATA0 offset
+	MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100b); // Write a1 from DATA0.
+	
+	MCFWriteReg32(dev, BDMDATA0, start_addr);
+	MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x1006); // Write t1 from DATA0.
+
+	MCFWriteReg32(dev, BDMDATA0, 0x000090c3); 
+	MCFWriteReg32(dev, DMCOMMAND, 0x002307b0);
+	MCFWriteReg32(dev, BDMDATA0, 0); 
+	MCFWriteReg32(dev, DMCOMMAND, 0x00230300); // Clear mstatus
+	MCFWriteReg32(dev, BDMDATA0, ram_base); 
+	MCFWriteReg32(dev, DMCOMMAND, 0x002307b1); // Write dpc from DATA0.
+	
+	MCFWriteReg32(dev, BDMDATA1, 1);
+	MCFWriteReg32(dev, DMCONTROL, 0x40000001);
+	if (iss->target_chip_type == CHIP_CH570) MCFWriteReg32(dev, DMCONTROL, 0x40000001);
+
+	MCFWriteReg32(dev, BDMDATA0, 0);
+	MCFWriteReg32(dev, BDMDATA1, 0);
+	
+	iss->microblob_running = start_addr;
+	return r;
+}
+
+void ch5xx_microblob_end(struct SWIOState * iss) {
+	struct SWIOState * dev = iss;
+	uint32_t dmdata0_offset = 0xe0000380;
+	MCFReadReg32(dev, DMHARTINFO, &dmdata0_offset);
+	dmdata0_offset = 0xe0000000 | (dmdata0_offset & 0x7ff);
+	MCFWriteReg32(dev, BDMDATA1, dmdata0_offset); // Signal to microblob that we're done writing
+	MCFDelayUS(10000);
+	MCFWriteReg32(dev, DMCONTROL, 0x80000001);
+	ch5xx_flash_close(dev);
+	iss->microblob_running = -1;
+}
+
+int ch5xx_write_flash_using_microblob(struct SWIOState * iss, uint32_t start_addr, uint8_t* data, uint32_t len) {
+	struct SWIOState * dev = iss;
+	int r = 0;
+	if ( iss->microblob_running < 0 ) ch5xx_microblob_init(iss, start_addr);
+	uint32_t dmdata0;
+	uint8_t timer = 0;
+	uint32_t byte = 0;
+	while(byte < len) {
+		// uint32_t current_word = *((uint32_t*)(data+byte));
+		uint32_t current_word = data[byte] | data[byte+1] << 8 | data[byte+2] << 16 | data[byte+3] << 24;
+
+		if (current_word) MCFWriteReg32( dev, BDMDATA0, current_word);
+		else MCFWriteReg32( dev, BDMDATA1, 2);
+		byte += 4;
+		// Wait every block to be written to flash and also new address set it takes ~1.5-2ms
+		if(!(byte & 0xFF)) {
+			do {
+				if ((timer++) > 200) {
+					return -1;
+				}
+				MCFReadReg32(dev, BDMDATA0, &dmdata0);
+			} while(dmdata0 != byte + start_addr);
+			timer = 0;
+			do {
+				if ((timer++) > 100) {
+					return -2;
+				}
+				MCFReadReg32(dev, BDMDATA0, &dmdata0);
+			} while(dmdata0);
+		}
+	}
+	return r;
+}
+
+// Writing flash using only PROGBUF. It's slower, but it doesn't touch RAM.
+int ch5xx_write_flash(struct SWIOState * iss, uint32_t start_addr, uint8_t* data, uint32_t len) {
+	struct SWIOState * dev = iss;
+
+	uint32_t position = 0;
+
+	if (iss->writing_flash == 0) {
+		ch5xx_flash_open(dev, 0xe0);
+		iss->writing_flash = 1;
+	}
+	
+	while(len) {
+		ch5xx_flash_addr(dev, 2, start_addr);
+
+		if (iss->statetag != STTAG("FWRT")) {
+			if ((iss->statetag & 0xff) != 'F') {
+				MCFWriteReg32(dev, DMABSTRACTAUTO, 0x00000000); // Disable Autoexec.
+				MCFWriteReg32(dev, BDMDATA0, R32_FLASH_DATA);
+				MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100d); // Write a3 from DATA0.
+			}
+			
+			MCFWriteReg32(dev, BDMDATA0, 21);
+			MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x1005); // Write t0 from DATA0.
+			
+			MCFWriteReg32(dev, DMPROGBUF0, 0x4791c298); // c.sw a4,0(a3); c.li a5,0x4;
+			MCFWriteReg32(dev, DMPROGBUF1, 0x00668703); // lb a4,6(a3);
+			MCFWriteReg32(dev, DMPROGBUF2, 0xfe074ee3); // blt a4,zero,-4;
+			MCFWriteReg32(dev, DMPROGBUF3, 0x00568323); // sb t0,6(a3);
+			MCFWriteReg32(dev, DMPROGBUF4, 0xfbed17fd); // c.addi a5,-1; c.bnez a5,-14;
+			MCFWriteReg32(dev, DMPROGBUF5, 0x00100073); // c.ebreak
+			iss->statetag = STTAG("FWRT");
+		}
+		
+		int r;
+		uint32_t rrv;
+		uint32_t block = len>256?256:len;
+		
+		for (uint32_t i = 0; i < block/4; i++) {
+			// uint32_t word = data[position] | data[position+1] << 8 | data[position+2] << 16 | data[position+3] << 24;
+			// MCFWriteReg32(dev, BDMDATA0, word);
+			MCFWriteReg32(dev, BDMDATA0, *((uint32_t*)(data+position)));
+			MCFWriteReg32(dev, DMCOMMAND, 0x0027100e); // Write a4 and execute.
+			
+			do {
+				r = MCFReadReg32(dev, DMABSTRACTCS, &rrv);
+				if(r) return r;
+				if (rrv & (0x700)) {
+					//fprintf(stderr, "Error: %08x\n", rrv);
+					return rrv;
+				}
+			} while((rrv & (1<<12)));
+			position += 4;
+		}
+
+		r = ch5xx_flash_wait(dev);
+		len -= block;
+		start_addr += block;
+	}
+	// ch5xx_flash_close(dev);
+	
+	return 0;
+}
+
+// This is only present in CH570/2 (as far as I know). I believe this serves the same purpose as "write safe" procedure.
+// Apparently the difference is that it enters "safe mode" permanently until it's closed, or chip is reset.
+// Maybe this is related to increased number of RWA registers in CH570/2.
+void ch570_disable_acauto(struct SWIOState * iss) {
+	struct SWIOState * dev = iss;
+	iss->statetag = STTAG( "XXXX" );
+	
+	MCFWriteReg32(dev, DMABSTRACTAUTO, 0x00000000); // Disable Autoexec.
+
+	MCFWriteReg32(dev, BDMDATA0, 0x4000101f);
+	MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x1005); // Write t0 from DATA0.
+	MCFWriteReg32(dev, BDMDATA0, 0x749da58b);
+	MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100a); // Write a0 from DATA0.
+	MCFWriteReg32(dev, BDMDATA0, 0x40001808);
+	MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100b); // Write a1 from DATA0.
+	MCFWriteReg32(dev, BDMDATA0, 0);
+	MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100c); // Write a2 from DATA0.
+	MCFWriteReg32(dev, BDMDATA0, 0x40001040);
+	MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100d); // Write a3 from DATA0.
+	MCFWriteReg32(dev, BDMDATA0, 0x57);
+	MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100e); // Write a4 from DATA0.
+	MCFWriteReg32(dev, BDMDATA0, 0xa8);
+	MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100f); // Write a5 from DATA0.
+
+	MCFWriteReg32(dev, DMPROGBUF0, 0x00c28023); // sb  a2,0x0(t0)
+	MCFWriteReg32(dev, DMPROGBUF1, 0x00e68023); // sb  a4,0x0(a3)
+	MCFWriteReg32(dev, DMPROGBUF2, 0x00f68023); // sb  a5,0x0(a3)
+	
+	MCFWriteReg32(dev, DMPROGBUF3, 0x00100073); // c.ebreak	
+	MCFWriteReg32(dev, DMCOMMAND, 0x00271000); // Execute program.
+
+	MCFWaitForDoneOp(dev);
+
+	iss->currentstateval = -1;
+}
+
+// Proper read/write protection is only available on CH570/2.
+// Funnily the chips I have only prevent you from WRITING the flash, when this protection is enabled.
+// But you won't be able to write them. Spent some time to figure out how to do this properly,
+// without relying on internal LinkE functionality
+void ch570_disable_read_protection(struct SWIOState * iss) {
+  struct SWIOState * dev = iss;
+	uint8_t options[4];
+
+	// MCFWriteByte(dev, 0x40001805, 0x10);
+	// MCFWriteByte(dev, 0x40001807, 0x5);
+	// ch5xx_write_safe(dev, 0x4000100A, 0x14, 0);
+	// ch5xx_write_safe(dev, 0x40001008, 0x48, 0);
+	// MCFWriteWord(dev, 0x40001000, 0x5555);
+	// MCFWriteWord(dev, 0x40001004, 0x7fff);
+	// ch5xx_write_safe(dev, 0x4000101f, 1, 0);
+	
+	CH5xxErase(dev, 0, 0, 1);
+	ch570_disable_acauto(dev);
+	MCFWriteWord(dev, 0x40001808, 0x749da58b);
+	
+	ch5xx_read_options_bulk(dev, 0x3EFFC, options, 4);
+	options[2] = 0x3a;
+	
+	CH5xxErase(dev, 0x3e000, 0x1000, 0);
+	ch5xx_write_flash(dev, 0x3EFFC, options, 4);
+}
+
+// Flash controller in CH5xx has built-in verify function. Not sure how usefule it is.
+// Minichlink currently doesn't use it anywhere. And even if we would start using it,
+// we probably would write a generic one the would work on all chips, including CH32.
+int ch5xx_verify_data(struct SWIOState * iss, uint32_t addr, uint8_t* data, uint32_t len) {
+	struct SWIOState * dev = iss;
+
+	uint32_t dmdata0;
+	int r;
+
+	// if (addr >= iss->target_chip->flash_size || (addr + len) > iss->target_chip->flash_size) {
+	// 	//fprintf(stderr, "Address is beyound flash space\n");
+	// 	return -1;
+	// }
+	
+	uint32_t dmdata0_offset = 0xe0000380;
+	MCFReadReg32(dev, DMHARTINFO, &dmdata0_offset);
+	dmdata0_offset = 0xe0000000 | (dmdata0_offset & 0x7ff);
+
+	ch5xx_flash_open(dev, 0x20);
+
+	ch5xx_flash_addr(dev, 0xb, addr);
+
+	if (iss->statetag != STTAG("FVER")) {
+		if ((iss->statetag & 0xff) != 'F') {
+			MCFWriteReg32(dev, DMABSTRACTAUTO, 0x00000000); // Disable Autoexec.
+			MCFWriteReg32(dev, BDMDATA0, R32_FLASH_DATA);
+			MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100d); // Write a3 from DATA0.
+		}
+		MCFWriteReg32(dev, BDMDATA0, dmdata0_offset);
+		MCFWriteReg32(dev, DMCOMMAND, 0x00230000 | 0x100a); // Write a0 from DATA0.
+
+		MCFWriteReg32(dev, DMPROGBUF0, 0x47910001); // c.nop; li a5,4;
+		MCFWriteReg32(dev, DMPROGBUF1, 0x00668703); // lb a4,6(a3);
+		MCFWriteReg32(dev, DMPROGBUF2, 0xfe074ee3); // blt a4,zero,-4;
+		MCFWriteReg32(dev, DMPROGBUF3, 0x00468703); // lb a4,4(a3);
+		MCFWriteReg32(dev, DMPROGBUF4, 0xfbed17fd); // c.addi a5,-1; c.bnez a5,-14;
+		MCFWriteReg32(dev, DMPROGBUF5, 0xc10c428c); // c.lw a1,0(a3); c.sw a1,0,(a0);
+		MCFWriteReg32(dev, DMPROGBUF6, 0x00100073); // ebreak
+
+		iss->statetag = STTAG("FVER");
+	}
+	
+	for (int i = 0; i < len; i += 4) {
+		uint8_t timeout = 200;
+		MCFWriteReg32(dev, DMCOMMAND, 0x00271000); // Execute program.
+		MCFReadReg32(dev, BDMDATA0, &dmdata0);
+		uint32_t word = data[i] | data[i+1] << 8 | data[i+2] << 16 | data[i+3] << 24;
+		// if (dmdata0 != *((uint32_t*)(data+i))) {
+		if (dmdata0 != word) {
+			do {
+				r = MCFReadReg32(dev, DMABSTRACTCS, &dmdata0);
+				if(r) return r;
+				if (dmdata0 & (0x700)) {
+					//fprintf(stderr, "Error in ch5xx_verify_data: %08x\n", dmdata0);
+					return -2;
+				}
+				timeout--;
+			} while((dmdata0 & (1<<12)) && timeout);
+			MCFReadReg32(dev, BDMDATA0, &dmdata0);
+			if (dmdata0 != word) {
+				//fprintf(stderr, "Verification failed at byte %d. dmdata0 = %08x, data = %08x\n", i, dmdata0, *((uint32_t*)(data+i)));
+				return -1;
+			}
+		}
+	}
+	ch5xx_flash_close(dev);
+	return 0;
+}
+
+// Flash controller of CH5xx chips has different mode of erasing for better performance.
+// You can erase in 256/4096/32768/65536 bytes chunks. 32K option is only present on CH32.
+int CH5xxErase(struct SWIOState * iss, uint32_t addr, uint32_t len, enum MemoryArea area) {
+	struct SWIOState * dev = iss;
+	
+	int ret = 0;
+	int sector_size = iss->sectorsize;
+	uint8_t flash_cmd;
+
+	ch5xx_set_clock(dev, 0);
+
+	uint32_t left = len;
+	int chunk_to_erase = addr;
+
+	ch5xx_flash_open(dev, 0xe0);
+	chunk_to_erase = chunk_to_erase & ~(sector_size-1);
+	while(left) {
+		if (!(chunk_to_erase & 0xFFFF) && left >= (64*1024)) {
+			sector_size = 64*1024;
+			flash_cmd = 0xd8;
+		} else if (iss->target_chip_type == CHIP_CH570 && !(chunk_to_erase & 0x7FFF) && left >= (32*1024)) {
+			sector_size = 32*1024;
+			flash_cmd = 0x52;
+		} else if (!(chunk_to_erase & 0xFFF) && left >= (4*1024) ) {
+			sector_size = 4*1024;
+			flash_cmd = 0x20;
+		} else {
+			if (iss->sectorsize == 256 || area == EEPROM_AREA) {
+				sector_size = 256;
+				flash_cmd = 0x81;
+			} else {
+				sector_size = 4*1024;
+				flash_cmd = 0x20; 
+			}
+		}
+
+		ch5xx_flash_addr(dev, flash_cmd, chunk_to_erase);
+		ret = ch5xx_flash_wait(dev);
+		if (!ret) return -1;
+		chunk_to_erase += sector_size;
+		if (left < sector_size) left = 0;
+		else left -= sector_size;
+	}
+	ch5xx_flash_close(dev);
+	return 0;
+}

--- a/rvswdio_programmer/ch5xx.h
+++ b/rvswdio_programmer/ch5xx.h
@@ -1,0 +1,51 @@
+#ifndef CH5XXH
+#define CH5XXH
+
+#define R8_SAFE_ACCESS_SIG     0x40001040
+#define R8_WDOG_COUNT          0x40001043
+#define R8_RESET_STATUS        0x40001044
+#define R8_GLOB_ROM_CFG        0x40001044
+#define R8_GLOB_CFG_INFO       0x40001045
+#define R8_RST_WDOG_CTRL       0x40001046
+#define R8_GLOB_RESET_KEEP     0x40001047
+#define R32_FLASH_DATA         0x40001800
+#define R32_FLASH_CONTROL      0x40001804
+#define R8_FLASH_DATA          0x40001804
+#define R8_FLASH_CTRL          0x40001806
+#define R8_FLASH_CFG           0x40001807
+
+#define MCFDetermineChipType(x)   DetermineChipTypeAndSectorInfo(x, NULL)
+#define MCFDelayUS             Delay_Us
+#define MCFReadByte            ReadByte
+#define MCFReadWord            ReadWord
+#define MCFWriteByte           WriteByte
+#define MCFWriteWord           WriteWord
+#define MCFWaitForDoneOp       WaitForDoneOp
+
+int ch5xx_set_clock(struct SWIOState * iss, uint32_t clock);
+uint8_t ch5xx_flash_wait(struct SWIOState * iss);
+void ch5xx_flash_close(struct SWIOState * iss);
+uint8_t ch5xx_flash_open(struct SWIOState * iss, uint8_t op);
+uint8_t ch5xx_flash_addr(struct SWIOState * iss, uint8_t cmd, uint32_t addr);
+uint8_t ch5xx_flash_in(struct SWIOState * iss);
+void ch5xx_flash_out(struct SWIOState * iss, uint8_t addr);
+void ch5xx_flash_end(struct SWIOState * iss);
+uint8_t ch5xx_flash_begin(struct SWIOState * iss, uint8_t cmd);
+void ch5xx_write_safe(struct SWIOState * iss, uint32_t addr, uint32_t value, uint8_t mode);
+int ch5xx_read_options(struct SWIOState * iss, uint32_t addr, uint8_t* buffer);
+int ch5xx_read_options_bulk(struct SWIOState * iss, uint32_t addr, uint8_t* buffer, uint32_t len);
+int ch5xx_read_secret_uuid(struct SWIOState * iss, uint8_t* buffer);
+int ch5xx_read_uuid(struct SWIOState * iss, uint8_t* buffer);
+int ch5xx_write_flash(struct SWIOState * iss, uint32_t start_addr, uint8_t* data, uint32_t len);
+int ch5xx_microblob_init(struct SWIOState * iss, uint32_t start_addr);
+void ch5xx_microblob_end(struct SWIOState * iss);
+int ch5xx_write_flash_using_microblob(struct SWIOState * iss, uint32_t start_addr, uint8_t* data, uint32_t len);
+void ch570_disable_acauto(struct SWIOState * iss);
+void ch570_disable_read_protection(struct SWIOState * iss);
+int ch5xx_verify_data(struct SWIOState * iss, uint32_t addr, uint8_t* data, uint32_t len);
+int CH5xxErase(struct SWIOState * iss, uint32_t addr, uint32_t len, enum MemoryArea area);
+int ch5xx_microblob_init(struct SWIOState * iss, uint32_t start_addr);
+
+#include "ch5xx.c"
+
+#endif

--- a/rvswdio_programmer/rvswdio_programmer.c
+++ b/rvswdio_programmer/rvswdio_programmer.c
@@ -112,7 +112,6 @@ static void HandleCommandBuffer( uint8_t * buffer )
 					// if we expect this, we can use 0x0e to get status.
 					funPinMode( PIN_TARGETPOWER, PIN_TARGETPOWER_MODE );
 					funDigitalWrite( PIN_TARGETPOWER, POWER_ON );
-					Delay_Ms(10);
 					int r = InitializeSWDSWIO( &state );
 					if( cmd == 0x0e )
 						*(retbuffptr++) = r;

--- a/rvswdio_programmer/usb_config.h
+++ b/rvswdio_programmer/usb_config.h
@@ -47,10 +47,26 @@ static const uint8_t special_hid_desc[] = {
 	HID_USAGE      ( 0x00 ),
 	HID_REPORT_SIZE ( 8 ),
 	HID_COLLECTION ( HID_COLLECTION_LOGICAL ),
+		HID_REPORT_COUNT   ( 7 ),
+		HID_REPORT_ID      ( 0xaa )
+		HID_USAGE          ( 0x01 ),
+		HID_FEATURE        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ),
+		HID_REPORT_COUNT   ( 63 ),
+		HID_REPORT_ID      ( 0xab )
+		HID_USAGE          ( 0x01 ),
+		HID_FEATURE        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ),
+		HID_REPORT_COUNT   ( 127 ),
+		HID_REPORT_ID      ( 0xac )
+		HID_USAGE          ( 0x01 ),
+		HID_FEATURE        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ),
 		HID_REPORT_COUNT   ( 78 ),
 		HID_REPORT_ID      ( 0xad )
 		HID_USAGE          ( 0x01 ),
-		HID_FEATURE        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,
+		HID_FEATURE        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ),
+    HID_REPORT_COUNT_N ( 263, 2 ),
+		HID_REPORT_ID      ( 0xae )
+		HID_USAGE          ( 0x01 ),
+		HID_FEATURE        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ),
 	HID_COLLECTION_END,
 };
 


### PR DESCRIPTION
Here is lots of stuff. It barely fits on v003, but it does. I think I can add *capability* check to report to minichlink what functions is it compiled with, and then minichlink can use generic functions for those that are missing. This will be encoded in programmer version after dot. Although I'm not sure why you want free space on your programmer...