### PR TITLE
Fixed bcdUSB field and bcdDevice field values

### DIFF
--- a/bootloader/usb_config.h
+++ b/bootloader/usb_config.h
@@ -33,14 +33,14 @@
 static const uint8_t device_descriptor[] = {
 	18, //Length
 	1,  //Type (Device)
-	0x10, 0x01, //Spec
+	0x00, 0x02, //Spec (bcdUSB)
 	0x0, //Device Class
 	0x0, //Device Subclass
 	0x0, //Device Protocol  (000 = use config descriptor)
 	0x08, //Max packet size for EP0 (This has to be 8 because of the USB Low-Speed Standard)
 	0x09, 0x12, //ID Vendor   //TODO: register this in http://pid.codes/howto/ or somewhere.
 	0x03, 0xb0, //ID Product
-	0x02, 0x00, //ID Rev
+	0x00, 0x00, //ID Rev (bcdDevice)
 	1, //Manufacturer string
 	2, //Product string
 	3, //Serial string


### PR DESCRIPTION
- bcdUSB 0x0110 (USB 1.1) to 0x0200 (USB 2.0)
- bcdDevice 0x0200 to 0x0000

The currently used Low-Speed is standardized on USB 2.0, but I don't know the effective difference between 1.1 and 2.0.