### PR TITLE
Fix LED statuses in demo_composite_hid

### DIFF
--- a/demo_composite_hid/demo_composite_hid.c
+++ b/demo_composite_hid/demo_composite_hid.c
@@ -20,6 +20,13 @@ int main()
 	}
 }
 
+void usb_handle_user_data( struct usb_endpoint * e, int current_endpoint, uint8_t * data, int len, struct rv003usb_internal * ist )
+{
+	if (current_endpoint == 2 && len > 0) {
+		LogUEvent(1139, data[0], 0, 0);
+	}
+}
+
 void usb_handle_user_in_request( struct usb_endpoint * e, uint8_t * scratchpad, int endp, uint32_t sendtok, struct rv003usb_internal * ist )
 {
 	if( endp == 1 )

--- a/demo_composite_hid/demo_composite_hid.c
+++ b/demo_composite_hid/demo_composite_hid.c
@@ -22,8 +22,8 @@ int main()
 
 void usb_handle_user_data( struct usb_endpoint * e, int current_endpoint, uint8_t * data, int len, struct rv003usb_internal * ist )
 {
-	if (current_endpoint == 2 && len > 0) {
-		LogUEvent(1139, data[0], 0, 0);
+	if (len > 0) {
+		LogUEvent(1139, data[0], 0, current_endpoint);
 	}
 }
 

--- a/demo_composite_hid/usb_config.h
+++ b/demo_composite_hid/usb_config.h
@@ -13,7 +13,7 @@
 #define RV003USB_EVENT_DEBUGGING 0
 #define RV003USB_HANDLE_IN_REQUEST 1
 #define RV003USB_OTHER_CONTROL 0
-#define RV003USB_HANDLE_USER_DATA 0
+#define RV003USB_HANDLE_USER_DATA 1
 #define RV003USB_HID_FEATURES 0
 
 #ifndef __ASSEMBLER__
@@ -104,11 +104,14 @@ static const uint8_t keyboard_hid_desc[] = {   /* USB report descriptor */
 		HID_REPORT_COUNT( 1 ),                        //     REPORT_COUNT (1)
 		HID_REPORT_SIZE( 3 ),                         //     REPORT_SIZE (3)
 		HID_OUTPUT( 0x03 ),                           //     OUTPUT (Cnst,Var,Abs) ; LED report padding
+		HID_REPORT_COUNT( 7 ),                        //     REPORT_COUNT (7)
+		HID_REPORT_SIZE( 8 ),                         //     REPORT_SIZE (8)
+		HID_OUTPUT( 0x03 ),						      //     OUTPUT (Cnst,Var,Abs) ; Padding to fill buffer to 8 bytes
 		HID_REPORT_COUNT( 6 ),                        //     REPORT_COUNT (6)
 		HID_REPORT_SIZE( 8 ),                         //     REPORT_SIZE (8)
 		HID_LOGICAL_MIN( 0 ),                         //     LOGICAL_MINIMUM (0)
 		HID_LOGICAL_MAX( 167 ),                       //     LOGICAL_MAXIMUM (167)  (Normally would be 101, but we want volume buttons)
-    	HID_USAGE_PAGE( HID_USAGE_PAGE_KEYBOARD ),     //     USAGE_PAGE (Keyboard)(Key Codes)
+    	HID_USAGE_PAGE( HID_USAGE_PAGE_KEYBOARD ),    //     USAGE_PAGE (Keyboard)(Key Codes)
     	HID_USAGE_MIN( 0x00 ),                        //     USAGE_MINIMUM (0)
 	    HID_USAGE_MAX( 167 ),                         //     USAGE_MAXIMUM (Keyboard Application)(101) (Now 167)
 	HID_INPUT( 0 ),                                   //   INPUT (Data,Ary,Abs)


### PR DESCRIPTION
I encountered an issue with receiving keyboard LED statuses (Caps Lock, Num Lock, etc.). During debugging, I noticed that the `usb_pid_handle_data` function discards buffers shorter than 3 bytes due to a length check in `usb_pid_handle_data`.

To address this, I modified the `demo_composite_hid example` by adding padding to ensure the buffer meets the minimum length requirement. This allows `usb_handle_user_data` to process the received messages correctly. My solution seems to fix the problem, but I want to bring this to your attention for further checking. This issue might also affect other examples (demo_pikokey_hid) in the project.