### PR TITLE
Put the reset flow into one function and make the binary smaller:

### DIFF
--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -96,15 +96,6 @@ void boot_usercode() __attribute__((section(".boot_firmware"))) __attribute__((n
 uint32_t secret_xor __attribute__((section(".secret_address"))) __attribute__((used)) = 0;
 #endif
 
-void sysreset_flow()
-{
-    FLASH->BOOT_MODEKEYR = FLASH_KEY1;
-    FLASH->BOOT_MODEKEYR = FLASH_KEY2;
-    FLASH->STATR = 0; // 1<<14 is zero, so, boot user code.
-    // FLASH->CTLR = CR_LOCK_Set;    // Not needed, flash is locked at reboot (soft reboot counts, I checked)
-    PFIC->SCTLR = 1<<31;
-}
-
 void boot_usercode()
 {
 #ifdef BOOTLOADER_DEBUG_BOOT
@@ -116,7 +107,11 @@ void boot_usercode()
 	LOCAL_EXP(GPIO,USB_PORT)->BSHR = 1<<(USB_PIN_DM + 16);
 	asmDelay(1000000);
 #endif
-	sysreset_flow();
+	FLASH->BOOT_MODEKEYR = FLASH_KEY1;
+	FLASH->BOOT_MODEKEYR = FLASH_KEY2;
+	FLASH->STATR = 0; // 1<<14 is zero, so, boot user code.
+	// FLASH->CTLR = CR_LOCK_Set;    // Not needed, flash is locked at reboot (soft reboot counts, I checked)
+	PFIC->SCTLR = 1<<31;
 }
 
 int main()
@@ -282,7 +277,7 @@ int main()
 			{
 				// Boot to user program.
 #ifndef DISABLE_BOOTLOAD
-				sysreset_flow();
+				boot_usercode();
 #endif
 			}
 #ifdef BOOTLOADER_TIMEOUT_USB


### PR DESCRIPTION
- Remove the forgotten FLASH->CTLR = CR_LOCK_Set;
- Add sysreset_flow function before boot_usercode and replace

Default build binary size becomes 1876 B to 1868 B when `riscv64-unknown-elf-gcc -v` is `gcc version 14.2.0 (14.2.0+19)` on my Ubuntu 24.04