### PR TITLE
Improve the PikoKey:

### DIFF
--- a/demo_pikokey_hid/pikokey.c
+++ b/demo_pikokey_hid/pikokey.c
@@ -11,6 +11,11 @@ int main()
 	Delay_Ms(1); // Ensures USB re-enumeration after bootloader or reset; Spec demand >2.5µs ( TDDIS )
 	systick_init();
 	GPIO_Init_All();
+
+	// Convert PD1 from SWIO to GPIO
+	AFIO->PCFR1 &= ~(AFIO_PCFR1_SWJ_CFG);
+	AFIO->PCFR1 |= AFIO_PCFR1_SWJ_CFG_DISABLE;
+
 	ButtonMatrix_Init(&btn_matrix); // Initialize button matrix state
 	Debounce_Init(&debounce_info); // Initialize debounce info
 	// printf( "Start\n");
@@ -29,7 +34,7 @@ int main()
 
 		// Scan the button matrix with debouncing
 		ButtonMatrix_Scan_Debounced(&btn_matrix, &debounce_info, current_time);
-		Delay_Ms(10);
+		Delay_Us(10); // Smaller is better, but too small causes hanging. Increase this delay when key map larger.
 
 	}
 }
@@ -41,15 +46,15 @@ void usb_handle_user_in_request( struct usb_endpoint * e, uint8_t * scratchpad, 
 	if( endp == 1 )
 	{
 		i++;
-		if(keypressed[0] == 1){
+		// if(keypressed[0] == 1){
 			tsajoystick[0] = keypressed[1];
 			for(uint8_t k=0;k<6;k++){
 				tsajoystick[2+k] = keypressed[2+k];
-				keypressed[2+k]=0;
+				// keypressed[2+k]=0;
 			}
-			keypressed[1] = 0;
-			keypressed[0] = 0;
-		}
+			// keypressed[1] = 0;
+			// keypressed[0] = 0;
+		// }
 		usb_send_data( tsajoystick, 8, 0, sendtok );
 		for(uint8_t k=0;k<8;k++){
 			tsajoystick[k] = 0;


### PR DESCRIPTION
- Change the event timing from a edge detection to a continuas detection that is popular
- Change the delay time from long to small, it allows smooth responses like general products

Note that, I tested with this. They does NOT have full size of a key map.
![PXL_20250213_150136355](https://github.com/user-attachments/assets/8e5e5fbd-3963-4525-804a-d95caa7ee463)