### PR TITLE
Update ch32fun submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "ch32v003fun"]
-	path = ch32v003fun
-	url = https://github.com/cnlohr/ch32v003fun
+[submodule "ch32fun"]
+	path = ch32fun
+	url = https://github.com/cnlohr/ch32fun

--- a/README.md
+++ b/README.md
@@ -83,15 +83,15 @@ And the following largely incomplete, but proof-of-concept projects:
 
 Note: CDC In windows likely CAN work, but I can't figure out how to do it.  Linux explicitly blacklists all low-speed USB Ethernet that I could find.  The MIDI example only demonstrates MIDI-OUT.
 
-### It's built on ch32v003fun
+### It's built on ch32fun
 
-[ch32v003fun](https://github.com/cnlohr/ch32v003fun) is a minimal development SDK of sorts for the CH32V003, allowing for maximum flexability without needing lots of code surrounding a HAL.
+[ch32fun](https://github.com/cnlohr/ch32fun) is a minimal development SDK of sorts for the CH32s, allowing for maximum flexibility without needing lots of code surrounding a HAL.
 
 ## General developer notes
 
 ### Care surrounding interrupts and critical sections.
 
-You are allowed to use interrupts and have critical sections, however, you should keep critical sections to approximately 40 or fewer cycles if possible.  Additionally if you are going to be using interrupts that will take longer than about 40 cycles to execute, you must enable preemption on that interrup.  For an example of how that works you can check the ws2812b SPI DMA driver in ch32v003fun.  The external pin-chane-interrupt **must** be the highest priority. And it **must never** be preempted.  While it's OK to have a short delay before it is fired, interrupting the USB reception code mid-transfer is prohibited.
+You are allowed to use interrupts and have critical sections, however, you should keep critical sections to approximately 40 or fewer cycles if possible.  Additionally if you are going to be using interrupts that will take longer than about 40 cycles to execute, you must enable preemption on that interrupt.  For an example of how that works you can check the ws2812b SPI DMA driver in ch32fun. The external pin-change-interrupt **must** be the highest priority. And it **must never** be preempted.  While it's OK to have a short delay before it is fired, interrupting the USB reception code mid-transfer is prohibited.
 
 ### Modifying headers / `usb_config.h`
 

--- a/bootloader/Makefile
+++ b/bootloader/Makefile
@@ -1,7 +1,7 @@
 all : flash
 
 TARGET:=bootloader
-CH32FUN:=../ch32v003fun/ch32fun
+CH32FUN:=../ch32fun/ch32fun
 TARGET_MCU:=CH32V003
 
 ADDITIONAL_C_FILES+=../rv003usb/rv003usb.S

--- a/bootloader/README.md
+++ b/bootloader/README.md
@@ -2,7 +2,7 @@
 
 The CH32V003 features 1920 byte additional space for an optional bootloader that runs before your regular code.
 
-This code implements a bootloader that enumerates as USB HID device (so no drivers are needed) and allows for flashing the regular code via USB using a custom version of [minichlink](https://github.com/cnlohr/ch32v003fun/tree/master/minichlink). This means you need a dedicated programmer like the Link-E only once to flash the bootloader. After that, firmware updates can simply be flashed via USB.
+This code implements a bootloader that enumerates as USB HID device (so no drivers are needed) and allows for flashing the regular code via USB using a custom version of [minichlink](https://github.com/cnlohr/ch32fun/tree/master/minichlink). This means you need a dedicated programmer like the Link-E only once to flash the bootloader. After that, firmware updates can simply be flashed via USB.
 
 By now, you can't update the bootloader using itself and minichlink - you can only flash regular user code.
 

--- a/bootloader/bootloader.c
+++ b/bootloader/bootloader.c
@@ -116,7 +116,7 @@ void boot_usercode()
 
 int main()
 {
-	// In the bootloader, the normal ch32v003fun startup doesn't happen, so to enable the systick, we have to manually enable it,
+	// In the bootloader, the normal ch32fun startup doesn't happen, so to enable the systick, we have to manually enable it,
 	// and configure it.  This enables and configures it for high speed.
 	SysTick->CTLR = 5;
 

--- a/bootloader/configurebootloader/Makefile
+++ b/bootloader/configurebootloader/Makefile
@@ -3,7 +3,7 @@ all : flash
 TARGET:=configurebootloader
 TARGET_MCU?=CH32V003
 
-include ../../ch32v003fun/ch32fun/ch32fun.mk
+include ../../ch32fun/ch32fun/ch32fun.mk
 
 flash : cv_flash
 clean : cv_clean

--- a/bootloader/make_win.bat
+++ b/bootloader/make_win.bat
@@ -5,4 +5,4 @@ del bootloader.hex
 del bootloader.lst
 del bootloader.map
 make build
-..\ch32v003fun\minichlink\minichlink.exe -a -w bootloader.bin bootloader -B
+..\ch32fun\minichlink\minichlink.exe -a -w bootloader.bin bootloader -B

--- a/bootloader/testblink/Makefile
+++ b/bootloader/testblink/Makefile
@@ -1,15 +1,15 @@
 all : testblink.bin busbflash
 
 TARGET:=testblink
-CH32V003FUN:=../../ch32v003fun/ch32v003fun
-MINICHLINK?=../../ch32v003fun/minichlink
+CH32FUN:=../../ch32fun/ch32fun
+MINICHLINK?=../../ch32fun/minichlink
 
 ADDITIONAL_C_FILES+=
 SYSTEM_C:=
 EXTRA_CFLAGS:=-I../rv003usb -I../lib
 
 busbflash : busbflash.c
-	gcc -o $@ $^ -ludev -I../../ch32v003fun/minichlink
+	gcc -o $@ $^ -ludev -I../../ch32fun/minichlink
 
 testflash : busbflash testblink.bin
 	./busbflash
@@ -23,7 +23,7 @@ LINKER_SCRIPT:=scratchpad.ld
 WRITE_SECTION:=bootloader
 FLASH_COMMAND:=./busbflash
 
-include ../../ch32v003fun/ch32v003fun/ch32v003fun.mk
+include ../../ch32fun/ch32fun/ch32fun.mk
 
 flash : busbflash cv_flash
 clean : cv_clean

--- a/bootloader/testblink/testblink.c
+++ b/bootloader/testblink/testblink.c
@@ -1,4 +1,4 @@
-#include "ch32v003fun.h"
+#include "ch32fun.h"
 
 //XXX TODO Make this so it can "run from main"
 void Scratchpad( uint8_t * buffer, uint32_t * keeprunning )

--- a/bootloader/testtop/Makefile
+++ b/bootloader/testtop/Makefile
@@ -1,7 +1,7 @@
 all : testtop
 
 testtop : testtop.c
-	gcc -o $@ $^ -I../../ch32v003fun/minichlink -ludev
+	gcc -o $@ $^ -I../../ch32fun/minichlink -ludev
 
 clean :
 	rm -rf *.o *~ testtop

--- a/demo_composite_hid/Makefile
+++ b/demo_composite_hid/Makefile
@@ -1,7 +1,7 @@
 all : flash
 
 TARGET:=demo_composite_hid
-CH32FUN:=../ch32v003fun/ch32fun
+CH32FUN:=../ch32fun/ch32fun
 TARGET_MCU:=CH32V003
 
 ADDITIONAL_C_FILES+=../rv003usb/rv003usb.S ../rv003usb/rv003usb.c

--- a/demo_exti/Makefile
+++ b/demo_exti/Makefile
@@ -1,7 +1,7 @@
 all : flash
 
 TARGET:=demo_exti
-CH32FUN:=../ch32v003fun/ch32fun
+CH32FUN:=../ch32fun/ch32fun
 TARGET_MCU:=CH32V003
 
 ADDITIONAL_C_FILES+=../rv003usb/rv003usb.S ../rv003usb/rv003usb.c

--- a/demo_exti/demo_exti.c
+++ b/demo_exti/demo_exti.c
@@ -50,7 +50,7 @@ int main()
 	funDigitalWrite( PC7, 0 );	// Enable pull-down for external interrupt
 	funDigitalWrite( PC0, 1 );	// Pin to toggle for demonstration
 
-	AFIO->EXTICR |= AFIO_EXTICR1_EXTI7_PC;
+	AFIO->EXTICR |= AFIO_EXTICR_EXTI7_PC;
 	EXTI->INTENR |= EXTI_INTENR_MR7; // Enable EXT7
 	EXTI->RTENR |= EXTI_RTENR_TR7;  // Rising edge trigger
 

--- a/demo_gamepad/Makefile
+++ b/demo_gamepad/Makefile
@@ -6,7 +6,7 @@ ADDITIONAL_C_FILES+=../rv003usb/rv003usb.S ../rv003usb/rv003usb.c
 EXTRA_CFLAGS:=-I../lib -I../rv003usb
 
 TARGET_MCU?=CH32V003
-include ../ch32v003fun/ch32fun/ch32fun.mk
+include ../ch32fun/ch32fun/ch32fun.mk
 
 flash : cv_flash
 clean : cv_clean

--- a/demo_hidapi/Makefile
+++ b/demo_hidapi/Makefile
@@ -1,7 +1,7 @@
 all : flash
 
 TARGET:=demo_hidapi
-CH32FUN:=../ch32v003fun/ch32fun
+CH32FUN:=../ch32fun/ch32fun
 TARGET_MCU:=CH32V003
 
 ADDITIONAL_C_FILES+=../rv003usb/rv003usb.S ../rv003usb/rv003usb.c

--- a/demo_hidapi/testtop/Makefile
+++ b/demo_hidapi/testtop/Makefile
@@ -1,10 +1,10 @@
 all : testtop ledtest
 
 testtop : testtop.c
-	gcc -o $@ $^ -I../../ch32v003fun/minichlink -ludev
+	gcc -o $@ $^ -I../../ch32fun/minichlink -ludev
 
 ledtest : ledtest.c
-	gcc -o $@ $^ -I../../ch32v003fun/minichlink -ludev
+	gcc -o $@ $^ -I../../ch32fun/minichlink -ludev
 
 clean :
 	rm -rf *.o *~ testtop ledtest

--- a/demo_hidapi/testtop/winbuild.bat
+++ b/demo_hidapi/testtop/winbuild.bat
@@ -1,1 +1,1 @@
-tcc testtop.c -I../../ch32v003fun/minichlink -lsetupapi
+tcc testtop.c -I../../ch32fun/minichlink -lsetupapi

--- a/demo_pikoball_hid/Makefile
+++ b/demo_pikoball_hid/Makefile
@@ -1,7 +1,7 @@
 all : flash
 
 TARGET:=pikoball
-CH32FUN:=../ch32v003fun/ch32fun
+CH32FUN:=../ch32fun/ch32fun
 TARGET_MCU:=CH32V003
 
 ADDITIONAL_C_FILES+=../rv003usb/rv003usb.S ../rv003usb/rv003usb.c

--- a/demo_pikokey_hid/Makefile
+++ b/demo_pikokey_hid/Makefile
@@ -1,7 +1,7 @@
 all : flash
 
 TARGET:=pikokey
-CH32FUN:=../ch32v003fun/ch32fun
+CH32FUN:=../ch32fun/ch32fun
 TARGET_MCU:=CH32V003
 
 ADDITIONAL_C_FILES+=../rv003usb/rv003usb.S ../rv003usb/rv003usb.c

--- a/demo_pikokey_hid/pikokey.c
+++ b/demo_pikokey_hid/pikokey.c
@@ -13,8 +13,8 @@ int main()
 	GPIO_Init_All();
 
 	// Convert PD1 from SWIO to GPIO
-	AFIO->PCFR1 &= ~(AFIO_PCFR1_SWJ_CFG);
-	AFIO->PCFR1 |= AFIO_PCFR1_SWJ_CFG_DISABLE;
+	AFIO->PCFR1 &= ~(AFIO_PCFR1_SWCFG);
+	AFIO->PCFR1 |= AFIO_PCFR1_SWCFG_DISABLE;
 
 	ButtonMatrix_Init(&btn_matrix); // Initialize button matrix state
 	Debounce_Init(&debounce_info); // Initialize debounce info

--- a/demo_terminal/Makefile
+++ b/demo_terminal/Makefile
@@ -1,5 +1,5 @@
 TARGET:=demo_terminal
-CH32FUN:=../ch32v003fun/ch32fun
+CH32FUN:=../ch32fun/ch32fun
 
 ADDITIONAL_C_FILES+=../rv003usb/rv003usb.S ../rv003usb/rv003usb.c
 EXTRA_CFLAGS:=-I../lib -I../rv003usb

--- a/demo_terminal/README.md
+++ b/demo_terminal/README.md
@@ -9,7 +9,7 @@ Edit ``usb_config.h`` to match your GPIO settings for USB;
 
 ``make flash``
 
-``make terminal_usb`` or ``../ch32v003fun/minichlink -kT -c 0x1209d003`` (VID=1209, PID=d003).
+``make terminal_usb`` or ``../ch32fun/minichlink -kT -c 0x1209d003`` (VID=1209, PID=d003).
 
 and use it like normal minichlink terminal.
 
@@ -45,7 +45,7 @@ Also enable debugprintf in ``funconfig.h``:
 
 By default ``printf`` uses a single wire programming interface to get those strings to the ``minichlink``'s terminal. You don't need to attach UART and use additional pins for it. Also it's fast.
 
-CH32V003 has a built-in Debug Module (further referenced as DM) that is used for programming and debugging via a compatible programmer. ``printf`` that is used by default in ch32v003fun leverages this DM to implement communication between the MCU and a host PC. How does it do this? It uses two debug registers ``DMDATA0`` and ``DMDATA1`` to write data to and read from.
+CH32V003 has a built-in Debug Module (further referenced as DM) that is used for programming and debugging via a compatible programmer. ``printf`` that is used by default in ch32fun leverages this DM to implement communication between the MCU and a host PC. How does it do this? It uses two debug registers ``DMDATA0`` and ``DMDATA1`` to write data to and read from.
 
 Now, what I thought, we could just read ``DMDATA0/1`` internally and send the contents of it via USB HID to a compatible terminal. Then we won't change any logic but only enhance it with our little addition. The pros of doing it this way are that we have both interface useful within same firmware with very little added code, and it becomes mostly portable.
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,9 +16,9 @@ lib_dir = doesntexist
 [env]
 platform = https://github.com/Community-PIO-CH32V/platform-ch32v.git
 framework = ch32v003fun
-; use ch32v003fun referenced in this project instead of a bleeding edge one
+; use ch32fun referenced in this project instead of a bleeding edge one
 platform_packages = 
-    framework-ch32v003fun@symlink://ch32v003fun
+    framework-ch32fun@symlink://ch32fun
 ; only build C file here, ASM file must be built in a separate folder!
 build_src_filter = +<rv003usb/rv003usb.c>
 extra_scripts =
@@ -98,5 +98,5 @@ framework =
 ; this explicitly does not have rv003usb/rv003usb.c included, because it is provided by bootloader.c
 build_src_filter = +<bootloader/bootloader.c>
 board_build.ldscript = bootloader/ch32v003fun-usb-bootloader.ld
-build_flags = ${env.build_flags} -DUSE_TINY_BOOT -Ich32v003fun/ch32fun
+build_flags = ${env.build_flags} -DUSE_TINY_BOOT -Ich32fun/ch32fun
 

--- a/rvswdio_programmer/Makefile
+++ b/rvswdio_programmer/Makefile
@@ -1,7 +1,7 @@
 all : flash
 
 TARGET:=rvswdio_programmer
-CH32FUN:=../ch32v003fun/ch32fun
+CH32FUN:=../ch32fun/ch32fun
 TARGET_MCU:=CH32V003
 
 ADDITIONAL_C_FILES+=../rv003usb/rv003usb.S ../rv003usb/rv003usb.c

--- a/testing/cdc_exp/Makefile
+++ b/testing/cdc_exp/Makefile
@@ -1,7 +1,7 @@
 all : flash
 
 TARGET:=cdc_exp
-CH32FUN:=../../ch32v003fun/ch32fun
+CH32FUN:=../../ch32fun/ch32fun
 TARGET_MCU:=CH32V003
 
 ADDITIONAL_C_FILES+=../../rv003usb/rv003usb.S ../../rv003usb/rv003usb.c

--- a/testing/demo_midi/Makefile
+++ b/testing/demo_midi/Makefile
@@ -2,7 +2,7 @@
 all : flash
 
 TARGET:=demo_midi
-CH32FUN:=../../ch32v003fun/ch32fun
+CH32FUN:=../../ch32fun/ch32fun
 TARGET_MCU:=CH32V003
 
 ADDITIONAL_C_FILES+=../../rv003usb/rv003usb.S ../../rv003usb/rv003usb.c

--- a/testing/demo_touchpad/Makefile
+++ b/testing/demo_touchpad/Makefile
@@ -2,7 +2,7 @@
 all : flash
 
 TARGET:=demo_touchpad
-CH32FUN:=../../ch32v003fun/ch32fun
+CH32FUN:=../../ch32fun/ch32fun
 TARGET_MCU:=CH32V003
 
 ADDITIONAL_C_FILES+=../../rv003usb/rv003usb.S ../../rv003usb/rv003usb.c

--- a/testing/demo_touchpad/top/Makefile
+++ b/testing/demo_touchpad/top/Makefile
@@ -1,6 +1,6 @@
 all : testtop
 testtop : testtop.c
-	gcc -o $@ $^ -I../../../ch32v003fun/minichlink -ludev
+	gcc -o $@ $^ -I../../../ch32fun/minichlink -ludev
 clean :
 	rm -rf *.o *~ testtop ledtest
 

--- a/testing/demo_touchpad/top/winbuild.bat
+++ b/testing/demo_touchpad/top/winbuild.bat
@@ -1,1 +1,1 @@
-tcc testtop.c -I../../../ch32v003fun/minichlink -lsetupapi
+tcc testtop.c -I../../../ch32fun/minichlink -lsetupapi

--- a/testing/demo_xinput/Makefile
+++ b/testing/demo_xinput/Makefile
@@ -1,7 +1,7 @@
 all : flash
 
 TARGET:=demo_xinput
-CH32FUN:=../../ch32v003fun/ch32fun
+CH32FUN:=../../ch32fun/ch32fun
 TARGET_MCU:=CH32V003
 
 ADDITIONAL_C_FILES+=../../rv003usb/rv003usb.S ../../rv003usb/rv003usb.c

--- a/testing/sandbox/Makefile
+++ b/testing/sandbox/Makefile
@@ -1,7 +1,7 @@
 all : flash
 
 TARGET:=sandbox
-CH32FUN:=../../ch32v003fun/ch32fun
+CH32FUN:=../../ch32fun/ch32fun
 TARGET_MCU:=CH32V003
 
 ADDITIONAL_C_FILES+=../../rv003usb/rv003usb.S ../../rv003usb/rv003usb.c

--- a/testing/test_ethernet/Makefile
+++ b/testing/test_ethernet/Makefile
@@ -2,7 +2,7 @@
 all : flash
 
 TARGET:=test_ethernet
-CH32FUN:=../../ch32v003fun/ch32fun
+CH32FUN:=../../ch32fun/ch32fun
 TARGET_MCU:=CH32V003
 
 ADDITIONAL_C_FILES+=../../rv003usb/rv003usb.S ../../rv003usb/rv003usb.c

--- a/testing/test_lcd_rbo12864h-wfi/Makefile
+++ b/testing/test_lcd_rbo12864h-wfi/Makefile
@@ -2,7 +2,7 @@
 all : flash
 
 TARGET:=test_lcd_rbo12864h-wfi
-CH32FUN:=../../ch32v003fun/ch32fun
+CH32FUN:=../../ch32fun/ch32fun
 TARGET_MCU:=CH32V003
 
 ADDITIONAL_C_FILES+=../../rv003usb/rv003usb.S ../../rv003usb/rv003usb.c

--- a/testing/test_lcd_rbo12864h-wfi/host/Makefile
+++ b/testing/test_lcd_rbo12864h-wfi/host/Makefile
@@ -1,7 +1,7 @@
 all : host
 
 host : host.c
-	gcc -g -o $@ $^ -I../../../ch32v003fun/minichlink -ludev -lusb-1.0 -lX11 -lXext -lGL -lm
+	gcc -g -o $@ $^ -I../../../ch32fun/minichlink -ludev -lusb-1.0 -lX11 -lXext -lGL -lm
 
 install_rules :
 	echo -ne "KERNEL==\"hidraw*\", SUBSYSTEM==\"hidraw\", MODE=\"0664\", GROUP=\"plugdev\"\n" | sudo tee /etc/udev/rules.d/20-hidraw.rules

--- a/testing/usb_cdc_uart/Makefile
+++ b/testing/usb_cdc_uart/Makefile
@@ -1,7 +1,7 @@
 all : flash
 
 TARGET:=uart_cdc
-CH32FUN:=../../ch32v003fun/ch32fun
+CH32FUN:=../../ch32fun/ch32fun
 TARGET_MCU:=CH32V003
 
 ADDITIONAL_C_FILES+=../../rv003usb/rv003usb.S ../../rv003usb/rv003usb.c


### PR DESCRIPTION
Initially I just wanted to update this because the bootloader didn't compile anymore with the old ch32fun commit

I then thought I could just replace the URL of the submodule to the new repo URL, but it just didn't sit right with me to leave the folder named like the old repo. So, I updated that one and all the relevant file paths too…

I hope I didn't miss anything, `make all` ran through w/o any problems…