### PR TITLE
Save a few bytes in the assembly

### DIFF
--- a/rv003usb/rv003usb.S
+++ b/rv003usb/rv003usb.S
@@ -471,16 +471,15 @@ usb_pid_handle_ack:
 	c.lw a2, 0(a4) //ist->current_endpoint -> endp;
 	c.slli a2, 5
 	c.add a2, a4
-	c.addi a2, ENDP_OFFSET // usb_endpoint eps[ENDPOINTS];
 
-	c.lw a0, (EP_TOGGLE_IN_OFFSET)(a2) // toggle_in=!toggle_in
+	c.lw a0, (ENDP_OFFSET+EP_TOGGLE_IN_OFFSET)(a2) // toggle_in=!toggle_in
 	c.li a1, 1
 	c.xor a0, a1
-	c.sw a0, (EP_TOGGLE_IN_OFFSET)(a2)
+	c.sw a0, (ENDP_OFFSET+EP_TOGGLE_IN_OFFSET)(a2)
 
-	c.lw a0, (EP_COUNT_OFFSET)(a2) // count_in
+	c.lw a0, (ENDP_OFFSET+EP_COUNT_OFFSET)(a2) // count_in
 	c.addi a0, 1
-	c.sw a0, (EP_COUNT_OFFSET)(a2)
+	c.sw a0, (ENDP_OFFSET+EP_COUNT_OFFSET)(a2)
 
 	c.j done_usb_message_in
 


### PR DESCRIPTION
For handle_se0_keepalive:
1. The code extracts the value of hsitrim, but it's directly overriden by the new value, so those instructions can just go.
2. It checks if the deviance is 0 and skips the next few instructions, but it's not really required. It only applies if a deviance exists 
*and* perfectly cancels out the existing windup to 0, which is really unlikely.
4. Loads the SYSTICK base address instead of the SYSTICK_CNT register, as that can be done with only a LUI (and the offset applied in the load)

For usb_pid_handle_ack:
1. use endp_offset as an offset during loading in usb_pid_handle_ack, instead of adding it to the base (same as in usb_pid_handle_setup)

It frees up a few bytes for the bootloader, allowing slightly more features/longer names.

If you disagree about 2., I'll drop it.

We could also remove delta_se0_cyccount, as it's only used for debugging purposes, saving another 2 bytes (and the 4 bytes in ram).

