### PR TITLE
Hint minichlink to upload bootloader to bootloader memory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ PROJECTS:=bootloader demo_composite_hid demo_hidapi demo_gamepad demo_pikokey_hi
 all : build
 
 build :
-	for dir in $(PROJECTS); do make -C $$dir build; done
+	for dir in $(PROJECTS); do $(MAKE) -C $$dir build || exit 1; done
 
 clean : $(PROJECTS)
-	for dir in $(PROJECTS); do make -C $$dir clean; done
+	for dir in $(PROJECTS); do $(MAKE) -C $$dir clean; done
 
 .PHONY : $(PROJECTS)
 

--- a/demo_pikoball_hid/help_functions.h
+++ b/demo_pikoball_hid/help_functions.h
@@ -230,7 +230,7 @@ void systick_init(void)
 	SysTick->CTLR = 0;
 	
 	/* enable the SysTick IRQ */
-	NVIC_EnableIRQ(SysTicK_IRQn);
+	NVIC_EnableIRQ(SysTick_IRQn);
 	
 	/* Set the tick interval to 1ms for normal op */
 	SysTick->CMP = (FUNCONF_SYSTEM_CORE_CLOCK/1000)-1;

--- a/demo_pikokey_hid/help_functions.h
+++ b/demo_pikokey_hid/help_functions.h
@@ -310,7 +310,7 @@ void systick_init(void)
 	SysTick->CTLR = 0;
 	
 	/* enable the SysTick IRQ */
-	NVIC_EnableIRQ(SysTicK_IRQn);
+	NVIC_EnableIRQ(SysTick_IRQn);
 	
 	/* Set the tick interval to 1ms for normal op */
 	SysTick->CMP = (FUNCONF_SYSTEM_CORE_CLOCK/1000)-1;

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@ platform = https://github.com/Community-PIO-CH32V/platform-ch32v.git
 framework = ch32v003fun
 ; use ch32fun referenced in this project instead of a bleeding edge one
 platform_packages = 
-    framework-ch32fun@symlink://ch32fun
+    framework-ch32v003fun@symlink://ch32fun
 ; only build C file here, ASM file must be built in a separate folder!
 build_src_filter = +<rv003usb/rv003usb.c>
 extra_scripts =

--- a/platformio.ini
+++ b/platformio.ini
@@ -58,7 +58,7 @@ build_src_filter = ${env.build_src_filter} +<demo_exti>
 
 [env:demo_gamepad]
 extends = rv003usb_base_v003
-build_src_filter = ${env.build_src_filter} +<demo_exti>
+build_src_filter = ${env.build_src_filter} +<demo_gamepad>
 
 [env:demo_hidapi]
 extends = rv003usb_base_v003

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,6 +30,16 @@ extra_scripts =
   pre:.github/build_rv003usb.py
 ; for rv003usb.h to be found
 build_flags = -Irv003usb
+; default upload and debug protocol is "wch-link", using OpenOCD and
+; expecting a WCH-LinkE programming adapter.
+; To use minichlink (handles WCH-Link(E), USB ISP and some others), uncomment this
+;upload_protocol = minichlink
+; can also use minichlink for SWD debugging.
+;debug_tool = minichlink
+; additionally uncomment this to use ardulink on a specific COM port
+;upload_flags =
+;  -c
+;  COM3
 
 [rv003usb_base_v003]
 board = genericCH32V003F4U6
@@ -99,4 +109,6 @@ framework =
 build_src_filter = +<bootloader/bootloader.c>
 board_build.ldscript = bootloader/ch32v003fun-usb-bootloader.ld
 build_flags = ${env.build_flags} -DUSE_TINY_BOOT -Ich32fun/ch32fun
-
+; hint to minichlink uploader to upload it to bootloader memory instead of regular flash.
+; other uploaders do not need this because they operate on the ELF file, which contains the address information.
+board_upload.offset_address = bootloader


### PR DESCRIPTION
Enabled by

https://github.com/Community-PIO-CH32V/platform-ch32v/blob/f1ae11c7598460b59b8101ab0f6ba40202aa4e89/builder/main.py#L181-L191

Also add hints for how to enable upload with the minichlink tool, the same as they are in ch32fun.

Additionally fix compilation for `demo_pikoball_hid` and `demo_pikokey_hid`. They were using the old SysTick IRQ name that was changed in a backwards-compatibility breaking way per https://github.com/cnlohr/ch32fun/pull/724.

The Makefile based CI tried to build them and failed, but did not fail the CI job -- see https://github.com/cnlohr/rv003usb/actions/runs/20890271452/job/60020313632. This is due to a `for` loop in the top makefile looping over every example but not stopping if one fails fatally. 

Additionally fixed in the latest commit, along with compatibility fixes the same as https://github.com/cnlohr/ch32fun/pull/872.

Additionally fix the inclusion of TWO ch32fun framework packages introduced by #119. 