### PR TITLE
Fix small (1-3 byte) user data packets being ignored

### DIFF
--- a/rv003usb/rv003usb.c
+++ b/rv003usb/rv003usb.c
@@ -269,7 +269,7 @@ void usb_pid_handle_data( uint32_t this_token, uint8_t * data, uint32_t which_da
 
 
 #if RV003USB_HANDLE_USER_DATA || RV003USB_USE_REBOOT_FEATURE_REPORT || RV003USB_USB_TERMINAL
-	if( epno || ( !ist->setup_request && length > 3 )  )
+	if( epno || ( !ist->setup_request && length > 0 )  )
 	{
 #if RV003USB_USE_REBOOT_FEATURE_REPORT
 		if( ist->reboot_armed )


### PR DESCRIPTION
length is already reduced by 3 at https://github.com/cnlohr/rv003usb/blob/03266412df1f2aa3200709153fd9f371b051c0d9/rv003usb/rv003usb.c#L259

The result is that small user data packets (1-3 bytes) are dropped. This shows up when (for example) a feature has a 9 total byte length (`HID_REPORT_COUNT(8)` + 1 byte for `HID_REPORT_ID`) - the first 8 byte packet is passed to `usb_handle_user_data` but the second 1 byte packet is dropped.

