### PR TITLE
Fixes issues with bootloaders

### DIFF
--- a/bootloader_v006/Makefile
+++ b/bootloader_v006/Makefile
@@ -7,7 +7,9 @@ TARGET_MCU:=CH32V006
 ADDITIONAL_C_FILES+=../rv003usb/rv003usb.S ../rv003usb/rv003usb.c
 EXTRA_CFLAGS:=-I. -I../lib -I../rv003usb
 
-LINKER_SCRIPT:=ch32v006fun-usb-bootloader.ld
+LINKER_SCRIPT:=ch32v006-usb-bootloader.ld
+# LINKER_SCRIPT:=ch32v005-usb-bootloader.ld
+# LINKER_SCRIPT:=ch32v002-usb-bootloader.ld
 WRITE_SECTION:=bootloader
 FLASH_COMMAND:=$(CH32FUN)/../minichlink/minichlink -a -w $(TARGET).bin $(WRITE_SECTION) -B
 

--- a/bootloader_v006/bootloader.c
+++ b/bootloader_v006/bootloader.c
@@ -58,9 +58,9 @@
 
 #define SCRATCHPAD_SIZE DATA_SIZE+128
 
-volatile int32_t runwordpad;
+__attribute__((section(".scratchpad"))) uint8_t scratchpad[SCRATCHPAD_SIZE];
+__attribute__((section(".runwordpad"))) volatile int32_t runwordpad;
 uint32_t runwordpadready = 0;
-uint8_t scratchpad[SCRATCHPAD_SIZE];
 uint32_t current_scratchpad_size = 128;
 
 volatile uint8_t reset_timeout = 0;
@@ -71,11 +71,14 @@ static inline void asmDelay(int delay) {
 "bne %[delay], x0, 1b\n" :[delay]"+r"(delay)  );
 }
 
-// #ifndef USB_PIN_DPU
-// // noreturn attribute saves 2-4 bytes. We can use it because we reboot the chip at the end of this function
-// void boot_usercode() __attribute__((section(".boot_firmware"))) __attribute__((noinline, noreturn));
-// #else
-// #endif
+#ifndef USB_PIN_DPU
+extern uint32_t _boot_firmware_xor;
+uint32_t secret_xor __attribute__((section(".secret_address"))) __attribute__((used)) = (uint32_t)(&_boot_firmware_xor);
+// noreturn attribute saves 2-4 bytes. We can use it because we reboot the chip at the end of this function
+void boot_usercode() __attribute__((section(".boot_firmware"))) __attribute__((noinline, noreturn));
+#else
+uint32_t secret_xor __attribute__((section(".secret_address"))) __attribute__((used)) = 0;
+#endif
 
 void boot_usercode()
 {
@@ -90,7 +93,6 @@ void boot_usercode()
 	FLASH->BOOT_MODEKEYR = FLASH_KEY1;
 	FLASH->BOOT_MODEKEYR = FLASH_KEY2;
 	FLASH->STATR = 0; // 1<<14 is zero, so, boot user code.
-	// FLASH->CTLR = CR_LOCK_Set;    // Not needed, flash is locked at reboot (soft reboot counts, I checked)
 	PFIC->SCTLR = 1<<31;
 }
 
@@ -98,6 +100,7 @@ int main()
 {
 	SystemInit();
 	usb_setup();
+	runwordpad = 0;
 	SysTick->CNT = BOOTLOADER_TIMEOUT_BASE;
 	// Enable GPIOs, TIMERs
 	RCC->APB2PCENR = RCC_APB2Periph_GPIOD | RCC_APB2Periph_GPIOC | RCC_APB2Periph_TIM1 | RCC_APB2Periph_GPIOA  | RCC_APB2Periph_AFIO | RCC_APB2Periph_TIM1;
@@ -106,7 +109,7 @@ int main()
 	funPinMode(BOOTLOADER_LED_PIN, (GPIO_Speed_10MHz | GPIO_CNF_OUT_PP));
 #endif
 
-#if defined(BOOTLOADER_BTN_PIN) && defined(BOOTLOADER_BTN_TRIG_LEVEL)
+#if BOOTLOADER_BTN_PIN && defined(BOOTLOADER_BTN_TRIG_LEVEL)
 
 	// Configure the Bootloader Pin
 	#if defined(BOOTLOADER_BTN_PULL)
@@ -148,12 +151,12 @@ int main()
 	// localpad set to 0 disables timeout
 	// localpad counting down to 0 is used for executing code from scratchpad
 	int32_t localpad = (int32_t)SysTick->CNT;
+	BOOT_LED(1);
 	while(1)
 	{
 #if defined(BOOTLOADER_TIMEOUT_PWR_MS) && BOOTLOADER_TIMEOUT_PWR_MS
 		if( localpad < 0 )
 		{
-			BOOT_LED(1);
 			localpad = (int32_t)SysTick->CNT;
 			if( localpad >= 0 )
 			{
@@ -176,8 +179,7 @@ int main()
 					4-bytes:        LONG( 0x1234abcd )
 
 					After the scratchpad is the runpad, its structure is:
-					4-bytes:   int32_t  if negative, how long to go before bootloading.  If 0, do nothing.  If positive, execute.
-						... 1kB of totally free space.
+					4-bytes:   int32_t  if negative, how long to go before bootloading.  If 0, do nothing.  If positive, execute..
 				*/
 				typedef void (*setype)( uint32_t *, volatile int32_t * );
 				setype scratchexec = (setype)(scratchpad+4);

--- a/bootloader_v006/ch32v002-usb-bootloader.ld
+++ b/bootloader_v006/ch32v002-usb-bootloader.ld
@@ -3,8 +3,9 @@ ENTRY( InterruptVector )
 MEMORY
 {
 	/* Actually at 0x1FFFF000 but the system maps it to 0x00000000 */
-	FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 3328
-	RAM (xrw)	: ORIGIN = 0x20000000, LENGTH = 8K
+	FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 3324
+	SECRET (rx) : ORIGIN = 0x00000CFC, LENGTH = 4
+	RAM (xrw)	: ORIGIN = 0x20000000, LENGTH = 4K
 }
 
 SECTIONS
@@ -44,7 +45,7 @@ SECTIONS
 	} >FLASH AT>FLASH
 
 	PROVIDE( _etext = . );
-	PROVIDE( _eitcm = . );	
+	PROVIDE( _eitcm = . );
 
 	.preinit_array :
 	{
@@ -112,6 +113,12 @@ SECTIONS
 		PROVIDE(_data_lma = .);
 	} >FLASH AT>FLASH
 
+	.secret_address :
+	{
+		. = ALIGN(4);
+		KEEP(*(.secret_address))
+	} >SECRET
+
 	.data :
 	{
 		. = ALIGN(4);
@@ -140,17 +147,23 @@ SECTIONS
 		*(.sbss*)
 		*(.gnu.linkonce.sb.*)
 		*(.bss*)
-		*(.gnu.linkonce.b.*)	
+		*(.gnu.linkonce.b.*)
 		*(COMMON*)
 		. = ALIGN(4);
 		PROVIDE( _ebss = .);
 	} >RAM AT>FLASH
 
+	.scratchpad (NOLOAD) :
+	{
+		. = ALIGN(4);
+		*(.scratchpad)
+		. = ALIGN(4);
+		*(.runwordpad*)
+		. = ALIGN(4);
+	} >RAM
+
 	PROVIDE( _end = _ebss);
 	PROVIDE( end = . );
 
-	PROVIDE( _eusrstack = ORIGIN(RAM) + LENGTH(RAM));	
+	PROVIDE( _eusrstack = ORIGIN(RAM) + LENGTH(RAM));
 }
-
-
-

--- a/bootloader_v006/ch32v005-usb-bootloader.ld
+++ b/bootloader_v006/ch32v005-usb-bootloader.ld
@@ -1,0 +1,169 @@
+ENTRY( InterruptVector )
+
+MEMORY
+{
+	/* Actually at 0x1FFFF000 but the system maps it to 0x00000000 */
+	FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 3324
+	SECRET (rx) : ORIGIN = 0x00000CFC, LENGTH = 4
+	RAM (xrw)	: ORIGIN = 0x20000000, LENGTH = 6K
+}
+
+SECTIONS
+{
+	.init :
+	{ 
+		_sinit = .;
+		. = ALIGN(4);
+		KEEP(*(SORT_NONE(.init)))
+		. = ALIGN(4);
+		_einit = .;
+	} >FLASH AT>FLASH
+
+	.boot_firmware :
+	{
+		. = ALIGN(4);
+		_boot_firmware_xor = ABSOLUTE((((ABSOLUTE(.)|0xCFC) - (ABSOLUTE(.)&0xCFC))<<16)|ABSOLUTE(.));
+		KEEP(*(.boot_firmware))
+		. = ALIGN(4);
+	}	>FLASH AT>FLASH
+
+	.text :
+	{
+		. = ALIGN(4);
+		*(.text)
+		*(.text.*)
+		*(.rodata)
+		*(.rodata*)
+		*(.gnu.linkonce.t.*)
+		. = ALIGN(4);
+	} >FLASH AT>FLASH 
+
+	.fini :
+	{
+		KEEP(*(SORT_NONE(.fini)))
+		. = ALIGN(4);
+	} >FLASH AT>FLASH
+
+	PROVIDE( _etext = . );
+	PROVIDE( _eitcm = . );
+
+	.preinit_array :
+	{
+		PROVIDE_HIDDEN (__preinit_array_start = .);
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN (__preinit_array_end = .);
+	} >FLASH AT>FLASH 
+	
+	.init_array :
+	{
+		PROVIDE_HIDDEN (__init_array_start = .);
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
+		PROVIDE_HIDDEN (__init_array_end = .);
+	} >FLASH AT>FLASH 
+	
+	.fini_array :
+	{
+		PROVIDE_HIDDEN (__fini_array_start = .);
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .dtors))
+		PROVIDE_HIDDEN (__fini_array_end = .);
+	} >FLASH AT>FLASH 
+	
+	.ctors :
+	{
+		/* gcc uses crtbegin.o to find the start of
+		 the constructors, so we make sure it is
+		 first.	Because this is a wildcard, it
+		 doesn't matter if the user does not
+		 actually link against crtbegin.o; the
+		 linker won't look for a file to match a
+		 wildcard.	The wildcard also means that it
+		 doesn't matter which directory crtbegin.o
+		 is in.	*/
+		KEEP (*crtbegin.o(.ctors))
+		KEEP (*crtbegin?.o(.ctors))
+		/* We don't want to include the .ctor section from
+		 the crtend.o file until after the sorted ctors.
+		 The .ctor section from the crtend file contains the
+		 end of ctors marker and it must be last */
+		KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .ctors))
+		KEEP (*(SORT(.ctors.*)))
+		KEEP (*(.ctors))
+	} >FLASH AT>FLASH 
+	
+	.dtors :
+	{
+		KEEP (*crtbegin.o(.dtors))
+		KEEP (*crtbegin?.o(.dtors))
+		KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .dtors))
+		KEEP (*(SORT(.dtors.*)))
+		KEEP (*(.dtors))
+	} >FLASH AT>FLASH 
+
+	.dalign :
+	{
+		. = ALIGN(4);
+		PROVIDE(_data_vma = .);
+	} >RAM AT>FLASH	
+
+	.dlalign :
+	{
+		. = ALIGN(4); 
+		PROVIDE(_data_lma = .);
+	} >FLASH AT>FLASH
+
+	.secret_address :
+	{
+		. = ALIGN(4);
+		KEEP(*(.secret_address))
+	} >SECRET
+
+	.data :
+	{
+		. = ALIGN(4);
+		__global_pointer$ = . + 0x3fc;
+		*(.gnu.linkonce.r.*)
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+		. = ALIGN(4);
+		*(.sdata .sdata.*)
+		*(.sdata2*)
+		*(.gnu.linkonce.s.*)
+		. = ALIGN(4);
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		. = ALIGN(4);
+		PROVIDE( _edata = .);
+	} >RAM AT>FLASH
+
+	.bss :
+	{
+		. = ALIGN(4);
+		PROVIDE( _sbss = .);
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON*)
+		. = ALIGN(4);
+		PROVIDE( _ebss = .);
+	} >RAM AT>FLASH
+
+	.scratchpad (NOLOAD) :
+	{
+		. = ALIGN(4);
+		*(.scratchpad)
+		. = ALIGN(4);
+		*(.runwordpad*)
+		. = ALIGN(4);
+	} >RAM
+
+	PROVIDE( _end = _ebss);
+	PROVIDE( end = . );
+
+	PROVIDE( _eusrstack = ORIGIN(RAM) + LENGTH(RAM));
+}

--- a/bootloader_v006/ch32v006-usb-bootloader.ld
+++ b/bootloader_v006/ch32v006-usb-bootloader.ld
@@ -1,0 +1,169 @@
+ENTRY( InterruptVector )
+
+MEMORY
+{
+	/* Actually at 0x1FFFF000 but the system maps it to 0x00000000 */
+	FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 3324
+	SECRET (rx) : ORIGIN = 0x00000CFC, LENGTH = 4
+	RAM (xrw)	: ORIGIN = 0x20000000, LENGTH = 8K
+}
+
+SECTIONS
+{
+	.init :
+	{ 
+		_sinit = .;
+		. = ALIGN(4);
+		KEEP(*(SORT_NONE(.init)))
+		. = ALIGN(4);
+		_einit = .;
+	} >FLASH AT>FLASH
+
+	.boot_firmware :
+	{
+		. = ALIGN(4);
+		_boot_firmware_xor = ABSOLUTE((((ABSOLUTE(.)|0xCFC) - (ABSOLUTE(.)&0xCFC))<<16)|ABSOLUTE(.));
+		KEEP(*(.boot_firmware))
+		. = ALIGN(4);
+	}	>FLASH AT>FLASH
+
+	.text :
+	{
+		. = ALIGN(4);
+		*(.text)
+		*(.text.*)
+		*(.rodata)
+		*(.rodata*)
+		*(.gnu.linkonce.t.*)
+		. = ALIGN(4);
+	} >FLASH AT>FLASH 
+
+	.fini :
+	{
+		KEEP(*(SORT_NONE(.fini)))
+		. = ALIGN(4);
+	} >FLASH AT>FLASH
+
+	PROVIDE( _etext = . );
+	PROVIDE( _eitcm = . );
+
+	.preinit_array :
+	{
+		PROVIDE_HIDDEN (__preinit_array_start = .);
+		KEEP (*(.preinit_array))
+		PROVIDE_HIDDEN (__preinit_array_end = .);
+	} >FLASH AT>FLASH 
+	
+	.init_array :
+	{
+		PROVIDE_HIDDEN (__init_array_start = .);
+		KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+		KEEP (*(.init_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
+		PROVIDE_HIDDEN (__init_array_end = .);
+	} >FLASH AT>FLASH 
+	
+	.fini_array :
+	{
+		PROVIDE_HIDDEN (__fini_array_start = .);
+		KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+		KEEP (*(.fini_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .dtors))
+		PROVIDE_HIDDEN (__fini_array_end = .);
+	} >FLASH AT>FLASH 
+	
+	.ctors :
+	{
+		/* gcc uses crtbegin.o to find the start of
+		 the constructors, so we make sure it is
+		 first.	Because this is a wildcard, it
+		 doesn't matter if the user does not
+		 actually link against crtbegin.o; the
+		 linker won't look for a file to match a
+		 wildcard.	The wildcard also means that it
+		 doesn't matter which directory crtbegin.o
+		 is in.	*/
+		KEEP (*crtbegin.o(.ctors))
+		KEEP (*crtbegin?.o(.ctors))
+		/* We don't want to include the .ctor section from
+		 the crtend.o file until after the sorted ctors.
+		 The .ctor section from the crtend file contains the
+		 end of ctors marker and it must be last */
+		KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .ctors))
+		KEEP (*(SORT(.ctors.*)))
+		KEEP (*(.ctors))
+	} >FLASH AT>FLASH 
+	
+	.dtors :
+	{
+		KEEP (*crtbegin.o(.dtors))
+		KEEP (*crtbegin?.o(.dtors))
+		KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .dtors))
+		KEEP (*(SORT(.dtors.*)))
+		KEEP (*(.dtors))
+	} >FLASH AT>FLASH 
+
+	.dalign :
+	{
+		. = ALIGN(4);
+		PROVIDE(_data_vma = .);
+	} >RAM AT>FLASH	
+
+	.dlalign :
+	{
+		. = ALIGN(4); 
+		PROVIDE(_data_lma = .);
+	} >FLASH AT>FLASH
+
+	.secret_address :
+	{
+		. = ALIGN(4);
+		KEEP(*(.secret_address))
+	} >SECRET
+
+	.data :
+	{
+		. = ALIGN(4);
+		__global_pointer$ = . + 0x3fc;
+		*(.gnu.linkonce.r.*)
+		*(.data .data.*)
+		*(.gnu.linkonce.d.*)
+		. = ALIGN(4);
+		*(.sdata .sdata.*)
+		*(.sdata2*)
+		*(.gnu.linkonce.s.*)
+		. = ALIGN(4);
+		*(.srodata.cst16)
+		*(.srodata.cst8)
+		*(.srodata.cst4)
+		*(.srodata.cst2)
+		*(.srodata .srodata.*)
+		. = ALIGN(4);
+		PROVIDE( _edata = .);
+	} >RAM AT>FLASH
+
+	.bss :
+	{
+		. = ALIGN(4);
+		PROVIDE( _sbss = .);
+		*(.sbss*)
+		*(.gnu.linkonce.sb.*)
+		*(.bss*)
+		*(.gnu.linkonce.b.*)
+		*(COMMON*)
+		. = ALIGN(4);
+		PROVIDE( _ebss = .);
+	} >RAM AT>FLASH
+
+	.scratchpad (NOLOAD) :
+	{
+		. = ALIGN(4);
+		*(.scratchpad)
+		. = ALIGN(4);
+		*(.runwordpad*)
+		. = ALIGN(4);
+	} >RAM
+
+	PROVIDE( _end = _ebss);
+	PROVIDE( end = . );
+
+	PROVIDE( _eusrstack = ORIGIN(RAM) + LENGTH(RAM));
+}

--- a/rv003usb/rv003usb.S
+++ b/rv003usb/rv003usb.S
@@ -1053,7 +1053,7 @@ InterruptVector:
 	c.li a4, 0
 1: c.sw a4, 0(a0)	// Clear RAM
 	c.addi a0, 4
-	blt a0, gp, 1b  // Iterate over RAM until it's cleared.
+	blt a0, sp, 1b  // Iterate over RAM until it's cleared.
 2:
 	//XXX WARNING: NO .DATA SECTION IS AVAILABLE HERE!
 	/* SystemInit48HSI */


### PR DESCRIPTION
- Clear all RAM in tiny boot, instead of clearing only half of it.
- Fix boot timeout in v006 bootloader, when used without a button.
- Add secret XOR partition to v006 bootloader, the same as in v003.
- Add separate ld scripts for different chips with different sizes of RAM.