### PR TITLE
fix bootloader DPU GPIO port override naming

### DIFF
--- a/bootloader/usb_config.h
+++ b/bootloader/usb_config.h
@@ -19,7 +19,7 @@
 #define USB_PORT D     // [A,C,D] GPIO Port to use with D+, D- and DPU
 #define USB_PIN_DP 3   // [0-4] GPIO Number for USB D+ Pin
 #define USB_PIN_DM 4   // [0-4] GPIO Number for USB D- Pin
-//#define USB_PORT_DPU A  // [A,C,D] Override GPIO Port for DPU
+//#define USB_DPU_PORT A  // [A,C,D] Override GPIO Port for DPU
 #define USB_PIN_DPU 5  // [0-7] GPIO for feeding the 1.5k Pull-Up on USB D- Pin; Comment out if not used / tied to 3V3!
 
 #define RV003USB_OPTIMIZE_FLASH 1


### PR DESCRIPTION
Took me a while to realize why the pullup wasn't working 😅 (I have the DPU GPIO on port C)